### PR TITLE
Add SPI

### DIFF
--- a/mcu/apollo4p/CMakeLists.txt
+++ b/mcu/apollo4p/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_AMBIQ_HAL_USE_WDT)
     zephyr_sources(hal/am_hal_wdt.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_I2C)
+if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPI)
     zephyr_sources(hal/mcu/am_hal_iom.c)
     zephyr_sources(hal/mcu/am_hal_cmdq.c)
     zephyr_sources(hal/mcu/am_hal_fault.c)


### PR DESCRIPTION
This PR enables the IOM SPI.

The zephyr sources that this PR adds are the same as in https://github.com/zephyrproject-rtos/hal_ambiq/pull/3.

This can be changed later to (depending on which PR will be merged in first):
```
if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPI )
    zephyr_sources(hal/mcu/am_hal_iom.c)
    zephyr_sources(hal/mcu/am_hal_cmdq.c)
    zephyr_sources(hal/mcu/am_hal_fault.c)
endif()
```
Instead of 2 separate if statements.