### PR TITLE
Add MCUCTRL file in hal_ambiq

### DIFF
--- a/mcu/apollo4p/CMakeLists.txt
+++ b/mcu/apollo4p/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_library_sources(hal/mcu/am_hal_interrupt.c)
 zephyr_library_sources(hal/mcu/am_hal_mram.c)
 zephyr_library_sources(hal/mcu/am_hal_rtc.c)
 zephyr_library_sources(hal/mcu/am_hal_utils.c)
+zephyr_library_sources(hal/mcu/am_hal_mcuctrl.c)
 
 if(CONFIG_AMBIQ_HAL_USE_GPIO)
     zephyr_library_sources(hal/am_hal_gpio.c)


### PR DESCRIPTION
This PR adds am_hal_mcuctrl.c in HAL for wide usage, e.g., the clock control.