### PR TITLE
Add Cooper (Apollo4x BLE controller) driver to support Bluetooth HCI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Ambiq HAL
 #
 # Copyright (c) 2023 Antmicro Ltd <www.antmicro.com>
+# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -10,4 +11,5 @@ if(CONFIG_AMBIQ_HAL)
         utils
         )
     add_subdirectory(mcu)
+    add_subdirectory(components)
 endif()

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Ambiq HAL Components
+#
+# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(bluetooth/am_devices_cooper.c)
+zephyr_include_directories(bluetooth)

--- a/components/bluetooth/am_devices_cooper.c
+++ b/components/bluetooth/am_devices_cooper.c
@@ -1,0 +1,1686 @@
+//*****************************************************************************
+//
+//! @file am_devices_cooper.c
+//!
+//! @brief An implementation of the Apollo inteface to Cooper using the IOM.
+//!
+//! @addtogroup cooper Cooper BLE Device Driver
+//! @ingroup devices
+//! @{
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Copyright (c) 2023, Ambiq Micro, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This is part of revision release_sdk_4_4_0-3c5977e664 of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "am_mcu_apollo.h"
+#include "am_bsp.h"
+#include "am_devices_cooper.h"
+
+//*****************************************************************************
+//
+// Timing and configuration.
+//
+//*****************************************************************************
+#define AM_DEVICES_COOPER_TIMEOUT                 10
+#define AM_DEVICES_COOPER_RETRY_TIMES             500
+
+#define OPCODE_H2WRITE_HANDSHAKE   0x80
+#define OPCODE_H2READ_HANDSHAKE    0x04
+#define OPCODE_READ_STATUS         0x08
+
+// Set to 1 to turn on logging for SBL diagnosis
+#define SBL_DEBUG_LOG_ON           0
+
+//*****************************************************************************
+//
+// Global state variables.
+//
+//*****************************************************************************
+am_devices_cooper_t gAmCooper[AM_DEVICES_COOPER_MAX_DEVICE_NUM];
+
+//*****************************************************************************
+//
+// Global SBL update data.
+//
+//*****************************************************************************
+am_devices_cooper_buffer(2) sLengthBytes;
+
+//
+//!
+//
+static am_devices_cooper_sbl_update_state_t gsSblUpdateState;
+
+//
+//!
+//
+static am_devices_cooper_sbl_update_data_t     g_sFwImage =
+{
+    0,
+    0,
+    AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_FW,
+    0
+
+};
+
+//
+//!
+//
+static am_devices_cooper_sbl_update_data_t     g_sInfo0PatchImage =
+{
+    0,
+    sizeof(am_sbl_info0_patch_blob_t),
+    AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_0,
+    0
+};
+
+//
+//!
+//
+static am_devices_cooper_sbl_update_data_t     g_sInfo1PatchImage =
+{
+    0,
+    0,
+    AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_1,
+    0
+};
+
+
+
+
+//*****************************************************************************
+//
+// COOPER_CS (54) - COOPER Master chip select.
+//
+//*****************************************************************************
+am_hal_gpio_pincfg_t g_AM_DEVICES_COOPER_SPI_CS =
+{
+#if defined(AM_PART_APOLLO4L) || defined(APOLLO4P_BLUE_KXR)
+    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_54_NCE54,
+#else
+    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_43_NCE43,
+#endif
+    .GP.cfg_b.eGPInput             = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .GP.cfg_b.eGPRdZero            = AM_HAL_GPIO_PIN_RDZERO_READPIN,
+    .GP.cfg_b.eIntDir              = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .GP.cfg_b.eGPOutCfg            = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .GP.cfg_b.eDriveStrength       = AM_HAL_GPIO_PIN_DRIVESTRENGTH_0P5X,
+    .GP.cfg_b.uSlewRate            = 0,
+    .GP.cfg_b.ePullup              = AM_HAL_GPIO_PIN_PULLUP_NONE,
+    .GP.cfg_b.uNCE                 = AM_HAL_GPIO_NCE_IOM4CE0,
+    .GP.cfg_b.eCEpol               = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW,
+    .GP.cfg_b.uRsvd_0              = 0,
+    .GP.cfg_b.ePowerSw             = AM_HAL_GPIO_PIN_POWERSW_NONE,
+    .GP.cfg_b.eForceInputEn        = AM_HAL_GPIO_PIN_FORCEEN_NONE,
+    .GP.cfg_b.eForceOutputEn       = AM_HAL_GPIO_PIN_FORCEEN_NONE,
+    .GP.cfg_b.uRsvd_1              = 0,
+};
+
+//*****************************************************************************
+//
+//  BLE_32M_CLK (46) - BLE 32M CLK OUT.
+//
+//*****************************************************************************
+am_hal_gpio_pincfg_t g_AM_DEVICES_COOPER_32M_CLK =
+{
+    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_46_CLKOUT_32M,
+    .GP.cfg_b.eGPInput             = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .GP.cfg_b.eGPRdZero            = AM_HAL_GPIO_PIN_RDZERO_READPIN,
+    .GP.cfg_b.eIntDir              = AM_HAL_GPIO_PIN_INTDIR_NONE,
+    .GP.cfg_b.eGPOutCfg            = AM_HAL_GPIO_PIN_OUTCFG_DISABLE,
+    .GP.cfg_b.eDriveStrength       = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .GP.cfg_b.uSlewRate            = 0,
+    .GP.cfg_b.ePullup              = AM_HAL_GPIO_PIN_PULLUP_NONE,
+    .GP.cfg_b.uNCE                 = 0,
+    .GP.cfg_b.eCEpol               = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW,
+    .GP.cfg_b.uRsvd_0              = 0,
+    .GP.cfg_b.ePowerSw             = AM_HAL_GPIO_PIN_POWERSW_NONE,
+    .GP.cfg_b.eForceInputEn        = AM_HAL_GPIO_PIN_FORCEEN_NONE,
+    .GP.cfg_b.eForceOutputEn       = AM_HAL_GPIO_PIN_FORCEEN_NONE,
+    .GP.cfg_b.uRsvd_1              = 0,
+};
+
+//*****************************************************************************
+//
+//  BLE_32K_CLK (45) - BLE 32K CLK OUT.
+//
+//*****************************************************************************
+am_hal_gpio_pincfg_t g_AM_DEVICES_COOPER_32K_CLK =
+{
+#if defined(AM_PART_APOLLO4L) || defined(APOLLO4P_BLUE_KXR)
+    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_4_32KHzXT,
+#else
+    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_45_32KHzXT,
+#endif
+    .GP.cfg_b.eGPInput             = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .GP.cfg_b.eGPRdZero            = AM_HAL_GPIO_PIN_RDZERO_READPIN,
+    .GP.cfg_b.eIntDir              = AM_HAL_GPIO_PIN_INTDIR_NONE,
+    .GP.cfg_b.eGPOutCfg            = AM_HAL_GPIO_PIN_OUTCFG_DISABLE,
+    .GP.cfg_b.eDriveStrength       = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .GP.cfg_b.uSlewRate            = 0,
+    .GP.cfg_b.ePullup              = AM_HAL_GPIO_PIN_PULLUP_NONE,
+    .GP.cfg_b.uNCE                 = 0,
+    .GP.cfg_b.eCEpol               = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW,
+    .GP.cfg_b.uRsvd_0              = 0,
+    .GP.cfg_b.ePowerSw             = AM_HAL_GPIO_PIN_POWERSW_NONE,
+    .GP.cfg_b.eForceInputEn        = AM_HAL_GPIO_PIN_FORCEEN_NONE,
+    .GP.cfg_b.eForceOutputEn       = AM_HAL_GPIO_PIN_FORCEEN_NONE,
+    .GP.cfg_b.uRsvd_1              = 0,
+};
+
+//*****************************************************************************
+//
+// BLE_CLKREQ (40) - BLE CLK request pin.
+//
+//*****************************************************************************
+am_hal_gpio_pincfg_t g_AM_DEVICES_COOPER_CLKREQ =
+{
+#if defined(AM_PART_APOLLO4L) || defined(APOLLO4P_BLUE_KXR)
+    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_52_GPIO,
+#else
+    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_40_GPIO,
+#endif
+    .GP.cfg_b.eGPInput             = AM_HAL_GPIO_PIN_INPUT_ENABLE,
+    .GP.cfg_b.eGPRdZero            = AM_HAL_GPIO_PIN_RDZERO_READPIN,
+    .GP.cfg_b.eIntDir              = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .GP.cfg_b.eGPOutCfg            = AM_HAL_GPIO_PIN_OUTCFG_DISABLE,
+    .GP.cfg_b.eDriveStrength       = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .GP.cfg_b.uSlewRate            = 0,
+    .GP.cfg_b.ePullup              = AM_HAL_GPIO_PIN_PULLUP_NONE,
+    .GP.cfg_b.uNCE                 = 0,
+    .GP.cfg_b.eCEpol               = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW,
+    .GP.cfg_b.uRsvd_0              = 0,
+    .GP.cfg_b.ePowerSw             = AM_HAL_GPIO_PIN_POWERSW_NONE,
+    .GP.cfg_b.eForceInputEn        = AM_HAL_GPIO_PIN_FORCEEN_NONE,
+    .GP.cfg_b.eForceOutputEn       = AM_HAL_GPIO_PIN_FORCEEN_NONE,
+    .GP.cfg_b.uRsvd_1              = 0,
+};
+
+static uint32_t sbl_status = 0;
+
+//*****************************************************************************
+//
+//  Set up pins for Cooper.
+//
+//*****************************************************************************
+void
+am_devices_cooper_pins_enable(void)
+{
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_RESET_PIN, am_hal_gpio_pincfg_output);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_IRQ_PIN, am_hal_gpio_pincfg_input);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_CLKREQ_PIN, am_hal_gpio_pincfg_input);
+#if (!AM_DEVICES_COOPER_QFN_PART)
+#if !defined(AM_PART_APOLLO4L)
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SWDIO, am_hal_gpio_pincfg_output);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SWCLK, am_hal_gpio_pincfg_output);
+    am_hal_gpio_output_clear(AM_DEVICES_COOPER_SWDIO);
+    am_hal_gpio_output_clear(AM_DEVICES_COOPER_SWCLK);
+#endif
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32M_CLK, g_AM_DEVICES_COOPER_32M_CLK);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32K_CLK, g_AM_DEVICES_COOPER_32K_CLK);
+#else
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32M_OSCEN_PIN, am_hal_gpio_pincfg_output);
+    am_hal_gpio_output_set(AM_DEVICES_COOPER_32M_OSCEN_PIN);
+    am_util_stdio_printf("\nThe Cooper QFN board is attached for debug\n");
+#endif
+}
+
+//*****************************************************************************
+//
+//  Disable pins for Cooper.
+//
+//*****************************************************************************
+void
+am_devices_cooper_pins_disable(void)
+{
+    am_hal_gpio_output_clear(AM_DEVICES_COOPER_RESET_PIN);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_IRQ_PIN, am_hal_gpio_pincfg_disabled);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_CLKREQ_PIN, am_hal_gpio_pincfg_disabled);
+#if (!AM_DEVICES_COOPER_QFN_PART)
+#if !defined(AM_PART_APOLLO4L)
+    am_hal_gpio_output_clear(AM_DEVICES_COOPER_SWDIO);
+    am_hal_gpio_output_clear(AM_DEVICES_COOPER_SWCLK);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SWDIO, am_hal_gpio_pincfg_disabled);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SWCLK, am_hal_gpio_pincfg_disabled);
+#endif
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32M_CLK, am_hal_gpio_pincfg_disabled);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32K_CLK, am_hal_gpio_pincfg_disabled);
+#else
+    am_hal_gpio_output_clear(AM_DEVICES_COOPER_32M_OSCEN_PIN);
+    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32M_OSCEN_PIN, am_hal_gpio_pincfg_disabled);
+#endif
+}
+
+//*****************************************************************************
+//
+//  Initialize the BLE controller driver.
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_init(uint32_t ui32Module, am_devices_cooper_config_t* pDevConfig, void** ppHandle, void** ppBleHandle)
+{
+    void* pBleHandle;
+    am_hal_iom_config_t     stIOMCOOPERSettings;
+    uint32_t      ui32Index = 0;
+    uint32_t g_CS[AM_REG_IOM_NUM_MODULES] =
+    {
+        0, 0, 0, 0, 0, 0, 0, 0
+    };
+    // Allocate a vacant device handle
+    for ( ui32Index = 0; ui32Index < AM_DEVICES_COOPER_MAX_DEVICE_NUM; ui32Index++ )
+    {
+        if ( gAmCooper[ui32Index].bOccupied == false )
+        {
+            break;
+        }
+    }
+    if ( ui32Index == AM_DEVICES_COOPER_MAX_DEVICE_NUM )
+    {
+        return AM_DEVICES_COOPER_STATUS_ERROR;
+    }
+    if ( (ui32Module > AM_REG_IOM_NUM_MODULES)  || (pDevConfig == NULL) )
+    {
+        return AM_DEVICES_COOPER_STATUS_ERROR;
+    }
+    //
+    // Enable fault detection.
+    //
+    am_hal_fault_capture_enable();
+    stIOMCOOPERSettings.ui32ClockFreq        = COOPER_IOM_FREQ;
+    stIOMCOOPERSettings.eInterfaceMode       = AM_HAL_IOM_SPI_MODE,
+    stIOMCOOPERSettings.eSpiMode             = AM_HAL_IOM_SPI_MODE_3,
+    stIOMCOOPERSettings.ui32NBTxnBufLength   = pDevConfig->ui32NBTxnBufLength;
+    stIOMCOOPERSettings.pNBTxnBuf            = pDevConfig->pNBTxnBuf;
+    //
+    // Initialize the IOM instance.
+    // Enable power to the IOM instance.
+    // Configure the IOM for Serial operation during initialization.
+    // Enable the IOM.
+    // HAL Success return is 0
+    //
+    if (am_hal_iom_initialize(ui32Module, &pBleHandle) ||
+            am_hal_iom_power_ctrl(pBleHandle, AM_HAL_SYSCTRL_WAKE, false) ||
+            am_hal_iom_configure(pBleHandle, &stIOMCOOPERSettings) ||
+            am_hal_iom_enable(pBleHandle))
+    {
+        return AM_DEVICES_COOPER_STATUS_ERROR;
+    }
+    else
+    {
+        //
+        // Configure the IOM pins.
+        //
+
+#if (SPI_MODULE == 2) && defined(AM_BSP_GPIO_IOM2_CS)
+#undef AM_BSP_GPIO_IOM2_CS
+#define AM_BSP_GPIO_IOM2_CS  AM_DEVICES_COOPER_SPI_CS // BGA&SIP share the same CS pin(NCE72) on the QFN shiled board
+#elif (SPI_MODULE == 4) && defined(AM_BSP_GPIO_IOM4_CS)
+#undef AM_BSP_GPIO_IOM4_CS
+#define AM_BSP_GPIO_IOM4_CS  AM_DEVICES_COOPER_SPI_CS
+#endif
+        am_bsp_iom_pins_enable(ui32Module, AM_HAL_IOM_SPI_MODE);
+        am_devices_cooper_pins_enable();
+#if (!AM_DEVICES_COOPER_QFN_PART)
+        //
+        // Enable crystals for Cooper
+        //
+        am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32K_ENABLE, 0);
+
+        //
+        // Enable the 32Mnz HF XTAL clock
+        //
+
+
+        am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_KICK_START, (void *)&g_amHalMcuctrlArgBLEDefault );
+
+
+#endif
+        am_devices_cooper_reset();
+
+        gAmCooper[ui32Index].pfnCallback = NULL;
+        gAmCooper[ui32Index].pCallbackCtxt = NULL;
+        gAmCooper[ui32Index].bBusy = false;
+        gAmCooper[ui32Index].bOccupied = true;
+        gAmCooper[ui32Index].bNeedCallback = true;
+        gAmCooper[ui32Index].bDMAComplete = false;
+        gAmCooper[ui32Index].bWakingUp = false;
+        gAmCooper[ui32Index].ui32CS = g_CS[ui32Module];
+        gAmCooper[ui32Index].ui32Module = ui32Module;
+        gAmCooper[ui32Index].ui32CSDuration = 100;
+        *ppBleHandle = gAmCooper[ui32Index].pBleHandle = pBleHandle;
+        *ppHandle = (void*)&gAmCooper[ui32Index];
+        // SBL checking
+        am_devices_cooper_image_update_init(*ppHandle, pDevConfig->pNBTxnBuf);
+        sbl_status = AM_DEVICES_COOPER_SBL_STATUS_INIT;
+        sbl_status = am_devices_cooper_update_image();
+
+        while ( (sbl_status != AM_DEVICES_COOPER_SBL_STATUS_OK) &&
+                ( sbl_status != AM_DEVICES_COOPER_SBL_STATUS_FAIL) )
+        {
+            while (am_devices_cooper_irq_read() == 0)
+            {
+                am_hal_delay_us(50);
+            }
+            sbl_status = am_devices_cooper_update_image();
+        }
+        //
+        // Return the status.
+        //
+        if (sbl_status == AM_DEVICES_COOPER_SBL_STATUS_OK)
+        {
+            // The CS assertation duration optimization only takes effect after V1.14
+            if ( gsSblUpdateState.ui32CooperFWImageVersion < 0x10E )
+            {
+                gAmCooper[ui32Index].ui32CSDuration = 300;
+            }
+            gAmCooper[ui32Index].ui32Firmver = gsSblUpdateState.ui32CooperFWImageVersion;
+            // need to wait a bit to jump from SBL to Cooper application firmware
+            am_util_delay_ms(10);
+            am_util_stdio_printf("BLE Controller Init Done\r\n");
+            return AM_DEVICES_COOPER_STATUS_SUCCESS;
+        }
+        else
+        {
+            // free up resource that won't be used.
+            am_devices_cooper_term(*ppHandle);
+            *ppHandle = NULL;
+            am_util_stdio_printf("BLE Controller SBL Error 0x%x\r\n", sbl_status);
+            return gsSblUpdateState.ui32CooperSblStatus;
+        }
+    }
+}
+
+//*****************************************************************************
+//
+//  De-Initialize the BLE controller driver.
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_term(void* pHandle)
+{
+    am_devices_cooper_t* pBle = (am_devices_cooper_t*)pHandle;
+    if ( pBle->ui32Module > AM_REG_IOM_NUM_MODULES )
+    {
+        return AM_DEVICES_COOPER_STATUS_ERROR;
+    }
+#if (!AM_DEVICES_COOPER_QFN_PART)
+    // Disable crystals
+    am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32K_DISABLE, 0);
+
+    am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_DISABLE, (void *)&g_amHalMcuctrlArgBLEDefault);
+#endif
+    // Disable the pins
+    am_bsp_iom_pins_disable(pBle->ui32Module, AM_HAL_IOM_SPI_MODE);
+    am_devices_cooper_pins_disable();
+    //
+    // Disable the IOM.
+    //
+    am_hal_iom_disable(pBle->pBleHandle);
+    //
+    // Disable power to and uninitialize the IOM instance.
+    //
+    // Clear local register values first
+    am_hal_iom_power_ctrl(pBle->pBleHandle, AM_HAL_SYSCTRL_WAKE, true);
+    am_hal_iom_power_ctrl(pBle->pBleHandle, AM_HAL_SYSCTRL_DEEPSLEEP, false);
+    am_hal_iom_uninitialize(pBle->pBleHandle);
+    // Free this device handle
+    pBle->bOccupied = false;
+    // Not in waking up state
+    pBle->bWakingUp = false;
+    //
+    // Return the status.
+    //
+    return AM_DEVICES_COOPER_STATUS_SUCCESS;
+}
+
+//*****************************************************************************
+//
+//  Reset BLE Controller.
+//
+//*****************************************************************************
+void
+am_devices_cooper_reset(void)
+{
+    am_hal_gpio_output_set(AM_DEVICES_COOPER_RESET_PIN);
+    am_util_delay_ms(20);
+    am_hal_gpio_output_clear(AM_DEVICES_COOPER_RESET_PIN);
+    am_util_delay_ms(20);
+    am_hal_gpio_output_set(AM_DEVICES_COOPER_RESET_PIN);
+    // Give some delay for the 32K clock stablization
+    am_util_delay_ms(700);
+}
+
+//*****************************************************************************
+//
+//  Enable the IOM bus
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_bus_enable(void* pHandle)
+{
+    am_devices_cooper_t* pBle = (am_devices_cooper_t*)pHandle;
+    if ( pBle->bOccupied != true )
+    {
+        return AM_DEVICES_COOPER_STATUS_INVALID_OPERATION;
+    }
+    // Mark the BLE interface busy so it doesn't get used by more than one
+    // interface.
+    if (pBle->bBusy == false)
+    {
+        pBle->bBusy = true;
+    }
+    else
+    {
+        return AM_DEVICES_COOPER_STATUS_BUS_BUSY;
+    }
+    am_hal_iom_power_ctrl(pBle->pBleHandle, AM_HAL_SYSCTRL_WAKE, true);
+    am_hal_iom_enable(pBle->pBleHandle);
+    return AM_DEVICES_COOPER_STATUS_SUCCESS;
+}
+
+//*****************************************************************************
+//
+//  Disable the IOM bus
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_bus_disable(void* pHandle)
+{
+    am_devices_cooper_t* pBle = (am_devices_cooper_t*)pHandle;
+    if ( pBle->bOccupied != true )
+    {
+        return AM_DEVICES_COOPER_STATUS_INVALID_OPERATION;
+    }
+    //
+    // Disable the IOM.
+    //
+    am_hal_iom_disable(pBle->pBleHandle);
+    //
+    // Disable power.
+    //
+    am_hal_iom_power_ctrl(pBle->pBleHandle, AM_HAL_SYSCTRL_DEEPSLEEP, true);
+    // Release the bus so someone else can use it.
+    pBle->bBusy = false;
+    return AM_DEVICES_COOPER_STATUS_SUCCESS;
+}
+
+//*****************************************************************************
+//
+//  Execute HCI blocking write to the BLE controller
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_blocking_write(void* pHandle, uint8_t ui8Type, uint32_t* pui32Data,
+                                 uint32_t ui32NumBytes, bool bWaitReady)
+{
+    uint32_t ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_SUCCESS;
+    uint32_t ui32WaitReadyCount = 0;
+    memset(&sLengthBytes.bytes, 0, 2);
+    //
+    // Make a structure for the IOM transfer.
+    //
+    am_hal_iom_transfer_t sIOMTransfer;
+    am_devices_cooper_t *pBle = (am_devices_cooper_t *)pHandle;
+
+    if ( pBle->bWakingUp )
+    {
+        ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_CONTROLLER_NOT_READY;
+        return ui32ErrorStatus;
+    }
+
+    // Awake IOM and lock the bus
+    ui32ErrorStatus = am_devices_cooper_bus_enable(pHandle);
+    if (ui32ErrorStatus != AM_DEVICES_COOPER_STATUS_SUCCESS)
+    {
+        return ui32ErrorStatus;
+    }
+
+#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+    sIOMTransfer.ui64Instr = OPCODE_H2WRITE_HANDSHAKE;
+#else
+    sIOMTransfer.ui32Instr = OPCODE_H2WRITE_HANDSHAKE;
+#endif
+    sIOMTransfer.ui32InstrLen = 1;
+    sIOMTransfer.eDirection = AM_HAL_IOM_RX;
+    sIOMTransfer.ui32NumBytes = 2;
+    sIOMTransfer.bContinue = true;
+    sIOMTransfer.uPeerInfo.ui32SpiChipSelect = pBle->ui32CS;
+    sIOMTransfer.pui32RxBuffer = sLengthBytes.words;
+    sIOMTransfer.ui8RepeatCount = 0;
+    sIOMTransfer.ui32PauseCondition = 0;
+    sIOMTransfer.ui32StatusSetClr = 0;
+    do
+    {
+        if (am_hal_iom_blocking_transfer(pBle->pBleHandle, &sIOMTransfer))
+        {
+            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE;
+            break;
+        }
+        // Cooper is not ready now
+        if ((sLengthBytes.bytes[0] != 0x68) || (sLengthBytes.bytes[1] != 0xA8))
+        {
+            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_CONTROLLER_NOT_READY;
+            //
+            // Cooper needs CS to low/asserted for 100us to detect wakeup request,
+            // and it takes about 2ms for Cooper to be ready to accept packet by asserting
+            // IRQ pin.
+            //
+            am_util_delay_us(pBle->ui32CSDuration);
+            // For the applications which do not enable IRQ interrupt, we need to do continuous try here
+            if ( bWaitReady )
+            {
+                //
+                // We need to set CS pin (first configured as GPIO) high to trigger Cooper to start wakeup process,
+                // after that we reconfigure CS pin back to IOM mode for next transfer.
+                //
+                am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SPI_CS, am_hal_gpio_pincfg_output);
+                am_hal_gpio_output_set(AM_DEVICES_COOPER_SPI_CS);
+
+#if (!AM_DEVICES_COOPER_QFN_PART)
+                // If the CS PIN is pulled high and then pulled low too quickly, Cooper may not be able to detect it.
+                am_util_delay_us(pBle->ui32CSDuration);
+#endif
+
+                am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SPI_CS, g_AM_DEVICES_COOPER_SPI_CS);
+                am_util_delay_us(1700);
+                //
+                // One count is about 2ms, if Cooper is not available to receive HCI packets
+                // in configured timeout, need to return the error status and jump out
+                // from the infinite trying.
+                //
+                if (ui32WaitReadyCount == AM_DEVICES_COOPER_RETRY_TIMES)
+                {
+                    ui32WaitReadyCount = 0;
+                    ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_TIMEOUT;
+                    break;
+                }
+                ui32WaitReadyCount ++;
+                continue;
+            }
+            else
+            {
+                pBle->bWakingUp = true;
+                break;
+            }
+        }
+        ui32WaitReadyCount = 0;
+        //
+        // If this isn't a "raw" transaction, we need to make sure the "type" byte
+        // gets through to the interface.
+        //
+        if (ui8Type != AM_DEVICES_COOPER_RAW)
+        {
+#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+            sIOMTransfer.ui64Instr = ui8Type;
+#else
+            sIOMTransfer.ui32Instr = ui8Type;
+#endif
+            sIOMTransfer.ui32InstrLen = 1;
+        }
+        else
+        {
+#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+            sIOMTransfer.ui64Instr = 0;
+#else
+            sIOMTransfer.ui32Instr = 0;
+#endif
+            sIOMTransfer.ui32InstrLen = 0;
+        }
+        sIOMTransfer.eDirection = AM_HAL_IOM_TX;
+        sIOMTransfer.ui32NumBytes = ui32NumBytes;
+        sIOMTransfer.pui32TxBuffer = pui32Data;
+        sIOMTransfer.bContinue = false;
+        //
+        // If the previous step succeeded, we can go ahead and send the data.
+        //
+        ui32ErrorStatus = am_hal_iom_blocking_transfer(pBle->pBleHandle, &sIOMTransfer);
+        if (ui32ErrorStatus != AM_DEVICES_COOPER_STATUS_SUCCESS)
+        {
+            //
+            // The layer above this one doesn't understand IOM errors, so we
+            // will intercept and rename it here.
+            //
+            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE;
+            break;
+        }
+        break;
+    }
+    while (1);
+
+    // Disable IOM to save power
+    am_devices_cooper_bus_disable(pHandle);
+
+    return ui32ErrorStatus;
+}
+
+
+//*****************************************************************************
+//
+//  Execute HCI blocking read from the BLE controller
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_blocking_read(void* pHandle, uint32_t* pui32Data,
+                                uint32_t* pui32BytesReceived)
+{
+    uint32_t ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_SUCCESS;
+    memset(&sLengthBytes.bytes, 0, 2);
+    am_devices_cooper_t* pBle = (am_devices_cooper_t*)pHandle;
+
+    // Skip if IRQ pin is low -- no pending incoimng packet from Cooper.
+    if (!am_devices_cooper_irq_read())
+    {
+        *pui32BytesReceived = 0;
+        return AM_DEVICES_COOPER_STATUS_SUCCESS;
+    }
+    //
+    // Make a structure for the IOM transfer.
+    //
+    am_hal_iom_transfer_t sIOMTransfer;
+    // Awake IOM and lock the bus
+    ui32ErrorStatus = am_devices_cooper_bus_enable(pHandle);
+    if (ui32ErrorStatus != AM_DEVICES_COOPER_STATUS_SUCCESS)
+    {
+        return ui32ErrorStatus;
+    }
+    do
+    {
+        sIOMTransfer.uPeerInfo.ui32SpiChipSelect = pBle->ui32CS;
+#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+        sIOMTransfer.ui64Instr = OPCODE_H2READ_HANDSHAKE;
+#else
+        sIOMTransfer.ui32Instr = OPCODE_H2READ_HANDSHAKE;
+#endif
+        sIOMTransfer.ui32InstrLen = 1;
+        sIOMTransfer.eDirection = AM_HAL_IOM_RX;
+        sIOMTransfer.ui32NumBytes = 2;
+        sIOMTransfer.pui32RxBuffer = sLengthBytes.words;
+        sIOMTransfer.bContinue = true;
+        sIOMTransfer.ui8RepeatCount = 0;
+        sIOMTransfer.ui32PauseCondition = 0;
+        sIOMTransfer.ui32StatusSetClr = 0;
+        //
+        // First we should get the byte available back
+        //
+        if (am_hal_iom_blocking_transfer(pBle->pBleHandle, &sIOMTransfer))
+        {
+            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE;
+            break;
+        }
+        if ((sLengthBytes.bytes[0] == 0) && (sLengthBytes.bytes[1] == 0))
+        {
+            *pui32BytesReceived = 0;
+            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_SUCCESS;
+            break;
+        }
+        //
+        // This is the second frame of the read, which contains the actual HCI
+        // data.
+        //
+#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+        sIOMTransfer.ui64Instr = 0;
+#else
+        sIOMTransfer.ui32Instr = 0;
+#endif
+        sIOMTransfer.ui32InstrLen = 0;
+        sIOMTransfer.pui32RxBuffer = pui32Data;
+        sIOMTransfer.ui32NumBytes = (sLengthBytes.bytes[0] +
+                                     (sLengthBytes.bytes[1] << 8));
+        sIOMTransfer.bContinue = false;
+        // check ui32NumBytes
+        if (sIOMTransfer.ui32NumBytes > AM_DEVICES_COOPER_MAX_RX_PACKET)
+        {
+            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_WRONG_DATA_LENGTH;
+            *pui32BytesReceived = 0;
+            break;
+        }
+        //
+        // Make sure the caller knows how many bytes we got.
+        //
+        *pui32BytesReceived = sIOMTransfer.ui32NumBytes;
+        //
+        // Execute the second part of the transfer.
+        //
+        ui32ErrorStatus = am_hal_iom_blocking_transfer(pBle->pBleHandle, &sIOMTransfer);
+        //
+        // A failure here indicates that the second part of the read was bad.
+        //
+        if (ui32ErrorStatus)
+        {
+            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE;
+            *pui32BytesReceived = 0;
+            break;
+        }
+    }
+    while (0);
+
+    // Disable IOM to save power
+    am_devices_cooper_bus_disable(pHandle);
+
+    return ui32ErrorStatus;
+}
+
+
+//*****************************************************************************
+//
+//  Send HCI raw command to the BLE controller
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_command_write(void* pHandle, uint32_t* pui32Cmd, uint32_t ui32Length, uint32_t* pui32Response, uint32_t* pui32BytesReceived)
+{
+    uint32_t ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_SUCCESS;
+    if ( !pui32Cmd || !pui32Response || !pui32BytesReceived )
+    {
+        return AM_DEVICES_COOPER_STATUS_INVALID_OPERATION;
+    }
+    do
+    {
+        ui32ErrorStatus = am_devices_cooper_blocking_write(pHandle,
+                          AM_DEVICES_COOPER_RAW,
+                          pui32Cmd,
+                          ui32Length, true);
+        if (ui32ErrorStatus)
+        {
+            break;
+        }
+        //
+        // Wait for the response, and return it to the caller via our variable.
+        //
+        WHILE_TIMEOUT_MS ( am_devices_cooper_irq_read() == 0, 5000, ui32ErrorStatus );
+        if (ui32ErrorStatus)
+        {
+            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_NO_RESPONSE;
+            break;
+        }
+        while(1)
+        {
+            ui32ErrorStatus = am_devices_cooper_blocking_read(pHandle, pui32Response, pui32BytesReceived);
+            // Keep reading until we get the corresponding response
+            if ((ui32ErrorStatus) || ((UINT32_TO_BYTE0(pui32Response[1]) == UINT32_TO_BYTE1(pui32Cmd[0])) && (UINT32_TO_BYTE1(pui32Response[1]) == UINT32_TO_BYTE2(pui32Cmd[0]))))
+            {
+                break;
+            }
+        }
+    } while (0);
+    //
+    // Return the status.
+    //
+    return ui32ErrorStatus;
+}
+
+//*****************************************************************************
+//
+// Check the state of the IRQ pin.
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_irq_read(void)
+{
+    return am_hal_gpio_input_read(AM_DEVICES_COOPER_IRQ_PIN);
+}
+
+//*****************************************************************************
+//
+// Check the state of the CLKREQ pin.
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_clkreq_read(void* pHandle)
+{
+    return am_hal_gpio_input_read(AM_DEVICES_COOPER_CLKREQ_PIN);
+}
+
+//*****************************************************************************
+//
+//  Set the 32M crystal frequency based on the tested values at customer side.
+//
+//*****************************************************************************
+uint32_t
+am_devices_cooper_crystal_trim_set(void *pHandle, uint32_t ui32TrimValue)
+{
+    if ( ui32TrimValue > 0x3FF )
+    {
+        return AM_DEVICES_COOPER_STATUS_ERROR;
+    }
+
+    //
+    // XTALHSCAP2TRIM : 6;  [5..0] xtalhs_cap2_trim
+    // XTALHSCAPTRIM : 4;   [9..6] xtalhs_cap_trim
+    //
+
+    g_ui32xtalhscap2trim = (ui32TrimValue & MCUCTRL_XTALHSTRIMS_XTALHSCAP2TRIM_Msk);
+    g_ui32xtalhscaptrim  = (ui32TrimValue & MCUCTRL_XTALHSTRIMS_XTALHSCAPTRIM_Msk) >> MCUCTRL_XTALHSTRIMS_XTALHSCAPTRIM_Pos;
+
+    return AM_DEVICES_COOPER_STATUS_SUCCESS;
+}
+
+
+
+/////////////////////////////////////////////////////////////////////////////////
+//
+// SBL Driver
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+//*****************************************************************************
+//
+// Read a packet from the SBL IOS.
+//
+//*****************************************************************************
+bool iom_slave_read(void* pHandle, uint32_t* pBuf, uint32_t* psize)
+{
+    am_secboot_wired_msghdr_t* msg;
+    uint32_t crc32;
+    am_devices_cooper_blocking_read(pHandle, pBuf, psize);
+    // Verify the received data CRC
+    msg = (am_secboot_wired_msghdr_t*)pBuf;
+    am_hal_crc32((uint32_t)&msg->msgType, msg->length - sizeof(uint32_t), &crc32);
+
+
+    return (crc32 == msg->crc32);
+}
+
+//*****************************************************************************
+//
+// Send a "HELLO" packet.
+//
+//*****************************************************************************
+void send_hello(void* pHandle)
+{
+    am_secboot_wired_msghdr_t msg;
+    msg.msgType = AM_SBL_HOST_MSG_HELLO;
+    msg.length = sizeof(am_secboot_wired_msghdr_t);
+    //
+    // Compute CRC
+    //
+    //PRT_INFO("send_hello: sending bytes: %d.\n", msg.length );
+    am_hal_crc32((uint32_t)&msg.msgType, msg.length - sizeof(uint32_t), &msg.crc32);
+    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)&msg, sizeof(msg), true);
+}
+
+//*****************************************************************************
+//
+// Send a "UPDATE" packet.
+//
+//*****************************************************************************
+void send_update(void* pHandle, uint32_t imgBlobSize)
+{
+    am_sbl_host_msg_update_t msg;
+    msg.msgHdr.msgType = AM_SBL_HOST_MSG_UPDATE;
+    msg.msgHdr.msgLength = sizeof(am_sbl_host_msg_update_t);
+    msg.imageSize = imgBlobSize;
+    // Check if we are downloading a newer FW versiion
+    if ((gsSblUpdateState.ui32CooperFWImageVersion < g_sFwImage.version)
+         || (gsSblUpdateState.ui32CooperVerRollBackConfig & 0x00000001))
+    {
+        msg.versionNumber = g_sFwImage.version;
+    }
+    else
+    {
+        msg.versionNumber = gsSblUpdateState.ui32CooperFWImageVersion;
+    }
+    msg.NumPackets = gsSblUpdateState.ui32TotalPackets + 1; // One addition packet as header will be a seperate packet
+
+    // imageSize will be zero if Apollo4 has no available image/patch for Cooper to load
+    // set maxPacketSize to invalid parameter to let Cooper to reply NACK and clear signature
+    if ( msg.imageSize == 0 )
+    {
+        msg.maxPacketSize = AM_DEVICES_COOPER_SBL_UPADTE_INVALID_PSI_PKT_SIZE;
+    }
+    else
+    {
+        msg.maxPacketSize = AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
+    }
+    //
+    // Compute CRC
+    //
+    am_hal_crc32((uint32_t)&msg.msgHdr.msgType, msg.msgHdr.msgLength - sizeof(uint32_t), &msg.msgHdr.msgCrc);
+    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)&msg, sizeof(msg), true);
+}
+
+//*****************************************************************************
+//
+// Send a "Data" packet.
+//
+//*****************************************************************************
+void send_data(void* pHandle, uint32_t address, uint32_t size, uint32_t pktNumber)
+{
+    // reuse same buffer for receiving
+    am_sbl_host_msg_data_t* msg = (am_sbl_host_msg_data_t*)gsSblUpdateState.pWorkBuf;
+    msg->msgHdr.msgType = AM_SBL_HOST_MSG_DATA;
+    msg->msgHdr.msgLength = sizeof(am_sbl_host_msg_data_t) + size;
+    msg->packetNumber = pktNumber;
+    memcpy((uint8_t*)msg->data, (uint8_t*)address, size);
+    //
+    // Compute CRC
+    //
+    am_hal_crc32((uint32_t) & (msg->msgHdr.msgType), msg->msgHdr.msgLength - sizeof(uint32_t), &msg->msgHdr.msgCrc);
+    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)msg, (sizeof(am_sbl_host_msg_data_t) + size), true);
+}
+
+//*****************************************************************************
+//
+// Send a "Reset" packet.
+//
+//*****************************************************************************
+void send_reset(void* pHandle)
+{
+    am_sbl_host_msg_reset_t msg;
+    msg.msgHdr.msgType = AM_SBL_HOST_MSG_RESET;
+    msg.msgHdr.msgLength = sizeof(am_sbl_host_msg_reset_t);
+    //
+    // Compute CRC
+    //
+    am_hal_crc32((uint32_t)&msg.msgHdr.msgType, msg.msgHdr.msgLength - sizeof(uint32_t), &msg.msgHdr.msgCrc);
+    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)&msg, sizeof(msg), true);
+}
+
+//*****************************************************************************
+//
+// Send a "FW Continue  packet.
+//
+//*****************************************************************************
+void send_fwContinue(void* pHandle)
+{
+    am_sbl_host_msg_fw_continue_t msg;
+    msg.msgHdr.msgType = AM_SBL_HOST_MSG_FW_CONTINUE;
+    msg.msgHdr.msgLength = sizeof(am_sbl_host_msg_fw_continue_t);
+    //
+    // Compute CRC
+    //
+    am_hal_crc32((uint32_t)&msg.msgHdr.msgType, msg.msgHdr.msgLength - sizeof(uint32_t), &msg.msgHdr.msgCrc);
+    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)&msg, sizeof(msg), true);
+}
+
+//*****************************************************************************
+//
+// Update the state machine based on the image to download
+//
+//*****************************************************************************
+static bool am_devices_cooper_sbl_update_state_data(uint32_t ui32updateType)
+{
+    // Pointer to the data to be updated
+    am_devices_cooper_sbl_update_data_t* p_sUpdateImageData = NULL;
+    if ( ui32updateType == AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_FW )
+    {
+        p_sUpdateImageData = &g_sFwImage;
+    }
+    else if ( ui32updateType == AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_0 )
+    {
+        p_sUpdateImageData = &g_sInfo0PatchImage;
+    }
+    else if ( ui32updateType == AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_1 )
+    {
+        p_sUpdateImageData = &g_sInfo1PatchImage;
+    }
+    else
+    {
+        return false;
+    }
+    // Check if the data is valid
+    if (    (p_sUpdateImageData != NULL)                &&
+            (p_sUpdateImageData->pImageAddress != 0 )    &&
+            (p_sUpdateImageData->imageSize != 0 )       &&
+            (p_sUpdateImageData->imageType == ui32updateType) )
+    {
+        // Load the INFO 0 Patch address
+        gsSblUpdateState.pImageBuf          = p_sUpdateImageData->pImageAddress;
+        // Image size
+        gsSblUpdateState.ui32ImageSize      = p_sUpdateImageData->imageSize;
+        // image type
+        gsSblUpdateState.ui32ImageType      = p_sUpdateImageData->imageType;
+        // Get the size of the data without headers
+        gsSblUpdateState.ui32DataSize       = gsSblUpdateState.ui32ImageSize - AM_DEVICES_COOPER_SBL_UPADTE_IMAGE_HDR_SIZE;
+        // Get the start address of the data without headers
+        gsSblUpdateState.pDataBuf           = gsSblUpdateState.pImageBuf + AM_DEVICES_COOPER_SBL_UPADTE_IMAGE_HDR_SIZE;
+        // Calculate number of packets
+        gsSblUpdateState.ui32TotalPackets   = gsSblUpdateState.ui32DataSize / AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
+        if (  (gsSblUpdateState.ui32DataSize % AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE) != 0 )
+        {
+            gsSblUpdateState.ui32TotalPackets++;
+        }
+        gsSblUpdateState.ui32PacketNumber = 0;
+        return true;
+    }
+
+    return false;
+}
+//*****************************************************************************
+//
+//  Initialize the Image Update state machine
+//
+//*****************************************************************************
+uint32_t am_devices_cooper_image_update_init(void* pHandle, uint32_t* pWorkBuf)
+{
+    // Check for the input data validity
+    if (pHandle != NULL)
+    {
+        // Initialize state machine
+        gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_INIT;
+        // Load the image address
+        gsSblUpdateState.pImageBuf          = NULL;
+        // Image size
+        gsSblUpdateState.ui32ImageSize      = 0;
+        // image type
+        gsSblUpdateState.ui32ImageType      = AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_NONE;
+        // Get the size of the data without headers
+        gsSblUpdateState.ui32DataSize       = 0;
+        // Get the start address of the data without headers
+        gsSblUpdateState.pDataBuf           = NULL;
+        // Calculate number of packets
+        gsSblUpdateState.ui32TotalPackets   = 0;
+        // Initialize Packet number in progress
+        gsSblUpdateState.ui32PacketNumber = 0;
+        //
+        // Save cooper device handle
+        //
+        gsSblUpdateState.pHandle = pHandle;
+        //
+        // Work buffer reuse non-blocking work buffer.
+        //
+        gsSblUpdateState.pWorkBuf = pWorkBuf;
+        // State is ready to go. Reset the cooper device
+        return 0;
+    }
+    else
+    {
+        // Return with error
+        return 1;
+    }
+}
+
+//*****************************************************************************
+//
+// @breif Update Image
+// @return uint32_t
+//
+//*****************************************************************************
+uint32_t am_devices_cooper_update_image(void)
+{
+    uint32_t     ui32dataPktSize = 0;
+    uint32_t     ui32Size        = 0;
+    uint32_t     ui32Ret         = AM_DEVICES_COOPER_SBL_STATUS_INIT;
+    am_sbl_host_msg_status_t*    psStatusMsg;
+    am_sbl_host_msg_ack_nack_t*  psAckMsg;
+    switch (gsSblUpdateState.ui32SblUpdateState)
+    {
+        case AM_DEVICES_COOPER_SBL_UPDATE_STATE_INIT:
+            //
+            // Send the "HELLO" message to connect to the interface.
+            //
+            send_hello(gsSblUpdateState.pHandle);
+            gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_HELLO;
+            // Tell application that we are not done with SBL
+            ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+            break;
+        case AM_DEVICES_COOPER_SBL_UPDATE_STATE_HELLO:
+            // Read the "STATUS" response from the IOS and check for CRC Error
+            if ( iom_slave_read(gsSblUpdateState.pHandle, (uint32_t*)gsSblUpdateState.pWorkBuf, &ui32Size) == false )
+            {
+                // Increment the Error Counter
+                gsSblUpdateState.ui32ErrorCounter++;
+                // Check if the Error has happened more than the limit
+                if ( gsSblUpdateState.ui32ErrorCounter > AM_DEVICES_COOPER_SBL_MAX_COMM_ERR_COUNT )
+                {
+                    // Return fail
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                }
+                else
+                {
+                    // Resend the previous message
+                    send_hello(gsSblUpdateState.pHandle);
+                    // Tell application that we are not done with SBL
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                }
+            }
+            else
+            {
+                // No CRC error and if there was one, then reset the error counter
+                if ( gsSblUpdateState.ui32ErrorCounter )
+                {
+                    gsSblUpdateState.ui32ErrorCounter = 0;
+                }
+                // Check the status
+                psStatusMsg = (am_sbl_host_msg_status_t*) (gsSblUpdateState.pWorkBuf);
+                gsSblUpdateState.ui32CooperSblStatus = psStatusMsg->bootStatus;
+                // Get the Cooper FW version
+                if ( psStatusMsg->versionNumber == AM_DEVICES_COOPER_SBL_DEFAULT_FW_VERSION )
+                {
+                    gsSblUpdateState.ui32CooperFWImageVersion = 0;
+                }
+                else
+                {
+                    gsSblUpdateState.ui32CooperFWImageVersion = psStatusMsg->versionNumber;
+                }
+                am_util_stdio_printf("BLE Controller Info:\n");
+                /*
+                 * Before Cooper firmware version 1.19 (0x00000113), only the lower 16-bit of 32-bit Cooper firmware version
+                 * word was used to identify Cooper firmware. It was limited to distinguish the difference of testing binaries.
+                 * To restructure the Cooper firmware version to a.b.c.d from a.b may solve this problem.
+                 * The higher 16-bit is used to identify the major and minor version of based release firmware.
+                 * The lower 16-bit is used to identify the version for testing before next release.
+                 * Originally the code only prints the lower 16-bit of FW version, need to print all the bytes
+                 * based on new structure of firmware version now.
+                 */
+                if ((psStatusMsg->versionNumber & 0xFFFF0000) == 0)
+                {
+                    am_util_stdio_printf("\tFW Ver:      %d.%d\n", (psStatusMsg->versionNumber & 0xF00) >> 8, psStatusMsg->versionNumber & 0xFF);
+                }
+                else
+                {
+                    am_util_stdio_printf("\tFW Ver:      %d.%d.%d.%d\n", (psStatusMsg->versionNumber & 0xFF000000) >> 24, (psStatusMsg->versionNumber & 0xFF0000) >> 16,
+                                                                        (psStatusMsg->versionNumber & 0xFF00) >> 8, psStatusMsg->versionNumber & 0xFF);
+                }
+                if (ui32Size == sizeof(am_sbl_host_msg_status_t))
+                {
+                    // Get the version rollback configuration
+                    gsSblUpdateState.ui32CooperVerRollBackConfig = psStatusMsg->verRollBackStatus;
+#if (SBL_DEBUG_LOG_ON == 1)
+                    if ( psStatusMsg->verRollBackStatus == AM_DEVICES_COOPER_SBL_STAT_VER_ROLL_BACK_EN )
+                    {
+                        am_util_stdio_printf("Version RollBack Enabled \n");
+                    }
+                    else if ( psStatusMsg->verRollBackStatus == AM_DEVICES_COOPER_SBL_STAT_VER_ROLL_BACK_DBL )
+                    {
+                        am_util_stdio_printf("Version RollBack Disabled \n");
+                    }
+                    else
+                    {
+                        am_util_stdio_printf("Version RollBack Config invalid !!! \n");
+                    }
+#endif
+                    am_util_stdio_printf("\tChip ID0:    0x%x\n", psStatusMsg->copperChipIdWord0);
+                    am_util_stdio_printf("\tChip ID1:    0x%x\n\n", psStatusMsg->copperChipIdWord1);
+
+                    gsSblUpdateState.ui32copperChipIdWord0 = psStatusMsg->copperChipIdWord0;
+                    gsSblUpdateState.ui32copperChipIdWord1 = psStatusMsg->copperChipIdWord1;
+
+                }
+                else
+                {
+                    gsSblUpdateState.ui32CooperVerRollBackConfig = 0x0;
+                }
+                #if (SBL_DEBUG_LOG_ON == 1)
+                am_util_stdio_printf("BLE Controller SBL Status:  0x%x\n", sbl_status);
+                am_util_stdio_printf("bootStatus 0x%x\n", psStatusMsg->bootStatus);
+                #endif
+                // check if the Boot Status is success
+                if ( psStatusMsg->bootStatus == AM_DEVICES_COOPER_SBL_STAT_RESP_SUCCESS )
+                {
+                    // Check if we have some FW available
+                    if (  am_devices_cooper_sbl_update_state_data(AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_FW) == true )
+                    {
+                        // Check if we have a newer FW version
+                        if ( psStatusMsg->versionNumber < g_sFwImage.version )
+                        {
+                            // We have newer FW available, Letus upgrade
+                            ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_FW;
+                            if ((g_sFwImage.version & 0xFFFF0000) == 0)
+                            {
+                                am_util_stdio_printf("Received new BLE Controller FW version = %d.%d Going for upgrade\n", (g_sFwImage.version & 0xF00) >> 8, g_sFwImage.version & 0xFF);
+                            }
+                            else
+                            {
+                                am_util_stdio_printf("Received new BLE Controller FW version = %d.%d.%d.%d Going for upgrade\n", (g_sFwImage.version & 0xFF000000) >> 24, (g_sFwImage.version & 0xFF0000) >> 16,
+                                                                                                                            (g_sFwImage.version & 0xFF00) >> 8, g_sFwImage.version & 0xFF);
+                            }
+                        }
+                    }
+                    // If we don't have any FW or any newer FW then continue with the current FW in Cooper
+                    if ( ui32Ret != AM_DEVICES_COOPER_SBL_STATUS_UPDATE_FW )
+                    {
+                        // We don't have any other FW, so continue with one already there is Cooper device
+                        gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_IMAGE_OK;
+                        // Not done yet
+                        ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                        am_util_stdio_printf("No new image to upgrade\n");
+                        // Send the command to continue to FW
+                        send_fwContinue(gsSblUpdateState.pHandle);
+                        am_util_stdio_printf("BLE Controller FW Auth Passed, Continue with FW\n");
+                    }
+                }
+                else if ( psStatusMsg->bootStatus == AM_DEVICES_COOPER_SBL_STAT_RESP_FW_UPDATE_REQ )
+                {
+                    am_util_stdio_printf("BLE Controller Requires FW\n");
+                    if (  am_devices_cooper_sbl_update_state_data(AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_FW) == true )
+                    {
+                        ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_FW;
+                    }
+                    else
+                    {
+                        ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_IMAGE_FAIL;
+                    }
+                }
+                else if ( psStatusMsg->bootStatus == AM_DEVICES_COOPER_SBL_STAT_RESP_INFO0_UPDATE_REQ )
+                {
+                    am_util_stdio_printf("BLE Controller Requires INFO 0\n");
+                    if ( am_devices_cooper_sbl_update_state_data(AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_0) == true )
+                    {
+                        ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_INFO_0;
+                    }
+                    else
+                    {
+                        ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_IMAGE_FAIL;
+                    }
+                }
+                else if ( psStatusMsg->bootStatus == AM_DEVICES_COOPER_SBL_STAT_RESP_INFO1_UPDATE_REQ )
+                {
+                    am_util_stdio_printf("BLE Controller Requires INFO 1\n");
+                    if ( am_devices_cooper_sbl_update_state_data(AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_1) == true )
+                    {
+                        ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_INFO_1;
+                    }
+                    else
+                    {
+                        ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_IMAGE_FAIL;
+                    }
+                }
+                else
+                {
+                    am_util_stdio_printf("BLE Controller Wrong Response\n");
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                }
+            }
+            if (  (ui32Ret == AM_DEVICES_COOPER_SBL_STATUS_OK) || (ui32Ret == AM_DEVICES_COOPER_SBL_STATUS_FAIL) ||
+                  (gsSblUpdateState.ui32SblUpdateState == AM_DEVICES_COOPER_SBL_UPDATE_STATE_IMAGE_OK) )
+            {
+                // Do nothing
+            }
+            else
+            {
+                // for the case ui32Ret == AM_DEVICES_COOPER_SBL_STATUS_UPDATE_IMAGE_FAIL,
+                // it indicates Cooper has available FW/Info0/Info1 signature and requests update,
+                // but Apollo4 does not have such image/patch at this moment, gsSblUpdateState.ui32ImageSize should be zero.
+                // Need to send_update with invalid parameter to let Cooper reply NACK and clear signature
+
+                // Update the state machine
+                gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_UPDATE;
+                // Send the update message
+                send_update(gsSblUpdateState.pHandle, gsSblUpdateState.ui32ImageSize);
+                ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+            }
+            break;
+        case AM_DEVICES_COOPER_SBL_UPDATE_STATE_UPDATE:
+            // Read the "ACK/NACK" response from the IOS and check for CRC Error
+            if ( iom_slave_read(gsSblUpdateState.pHandle, (uint32_t*)gsSblUpdateState.pWorkBuf, &ui32Size) == false )
+            {
+                // Increment the Error Counter
+                gsSblUpdateState.ui32ErrorCounter++;
+                // Check if the Error has happened more than the limit
+                if ( gsSblUpdateState.ui32ErrorCounter > AM_DEVICES_COOPER_SBL_MAX_COMM_ERR_COUNT )
+                {
+                    // Return fail
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                }
+                else
+                {
+                    // Resend the previous message
+                    send_update(gsSblUpdateState.pHandle, gsSblUpdateState.ui32ImageSize);
+                    // Tell application that we are not done with SBL
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                }
+            }
+            else
+            {
+                // No CRC error and if there was one, then reset the error counter
+                if ( gsSblUpdateState.ui32ErrorCounter )
+                {
+                    gsSblUpdateState.ui32ErrorCounter = 0;
+                }
+                // Get the response status
+                psAckMsg = (am_sbl_host_msg_ack_nack_t*)(gsSblUpdateState.pWorkBuf);
+                // Process the response
+                if ( (psAckMsg->msgHdr.msgType == AM_SBL_HOST_MSG_ACK) && (NULL != gsSblUpdateState.pImageBuf))
+                {
+                    // Save the status
+                    gsSblUpdateState.ui32CooperSblStatus = psAckMsg->status;
+                    // Change the state
+                    gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_DATA;
+                    // Send the Encrypted image header - first 64 bytes
+                    send_data(gsSblUpdateState.pHandle, (uint32_t)gsSblUpdateState.pImageBuf,
+                            AM_DEVICES_COOPER_SBL_UPADTE_IMAGE_HDR_SIZE, gsSblUpdateState.ui32PacketNumber);
+                    am_util_stdio_printf("BLE controller upgrade in progress, wait...\n");
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                }
+                else if ( (psAckMsg->msgHdr.msgType == AM_SBL_HOST_MSG_NACK) && (psAckMsg->status == AM_DEVICES_COOPER_SBL_ACK_RESP_INVALID_PARAM) )
+                {
+                    am_util_stdio_printf("Clear Cooper Signature, reset Cooper and talk with SBL again\n");
+                    // Add some delay for Cooper SBL to clear signature
+                    am_util_delay_ms(1200);
+                    am_devices_cooper_reset();
+                    gsSblUpdateState.pImageBuf        = NULL;
+                    gsSblUpdateState.ui32ImageSize    = 0;
+                    gsSblUpdateState.ui32ImageType    = AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_NONE;
+                    gsSblUpdateState.ui32DataSize     = 0;
+                    gsSblUpdateState.pDataBuf         = NULL;
+                    gsSblUpdateState.ui32TotalPackets = 0;
+                    gsSblUpdateState.ui32PacketNumber = 0;
+
+                    // Send the "HELLO" message to connect to the interface.
+                    send_hello(gsSblUpdateState.pHandle);
+                    gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_HELLO;
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                }
+                else
+                {
+                    am_util_stdio_printf("Update Failed !!!\n");
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                }
+            }
+            break;
+        case AM_DEVICES_COOPER_SBL_UPDATE_STATE_DATA:
+            // Read the "ACK/NACK" response from the IOS.
+            if ( iom_slave_read(gsSblUpdateState.pHandle, (uint32_t*)gsSblUpdateState.pWorkBuf, &ui32Size) == false )
+            {
+                // Increment the Error Counter
+                gsSblUpdateState.ui32ErrorCounter++;
+                // Check if the Error has happened more than the limit
+                if ( gsSblUpdateState.ui32ErrorCounter > AM_DEVICES_COOPER_SBL_MAX_COMM_ERR_COUNT )
+                {
+                    // Return fail
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                }
+                else
+                {
+                    // Resend the previous message
+                    if ( gsSblUpdateState.ui32PacketNumber == 0 )
+                    {
+                        // Send the Encrypted image header - first 64 bytes
+                        send_data(gsSblUpdateState.pHandle, (uint32_t)gsSblUpdateState.pImageBuf,
+                                  AM_DEVICES_COOPER_SBL_UPADTE_IMAGE_HDR_SIZE, gsSblUpdateState.ui32PacketNumber);
+                    }
+                    else
+                    {
+                        // Reset the packet counters to the previous ones, to resend the packet
+                        //gsSblUpdateState.ui32TotalPackets++;
+                        // increment the packet number as we have already sent the header
+                        //gsSblUpdateState.ui32PacketNumber--;
+                        //Check if this is the last packet - Increase by one as we have already decremented after TX
+                        if (  (gsSblUpdateState.ui32TotalPackets + 1) == 1 )
+                        {
+                            // Get the size of the leftover data
+                            ui32dataPktSize = gsSblUpdateState.ui32DataSize % AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
+                            if (ui32dataPktSize == 0)
+                            {
+                                ui32dataPktSize = AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
+                            }
+                        }
+                        else
+                        {
+                            ui32dataPktSize = AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
+                        }
+                        // Resend the same packet - Need to decrement the packet numbers as those are already incremented
+                        send_data(gsSblUpdateState.pHandle, (uint32_t) gsSblUpdateState.pDataBuf + ( (gsSblUpdateState.ui32PacketNumber - 1) * AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE),
+                                  ui32dataPktSize, gsSblUpdateState.ui32PacketNumber);
+                    }
+                    // Tell application that we are not done with SBL
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                }
+            }
+            else
+            {
+                // No CRC error and if there was one, then reset the error counter
+                if ( gsSblUpdateState.ui32ErrorCounter )
+                {
+                    gsSblUpdateState.ui32ErrorCounter = 0;
+                }
+                // Get the response status
+                psAckMsg = (am_sbl_host_msg_ack_nack_t*)(gsSblUpdateState.pWorkBuf);
+                // Save the status
+                gsSblUpdateState.ui32CooperSblStatus = psAckMsg->status;
+                if (  (psAckMsg->srcMsgType == AM_SBL_HOST_MSG_DATA ) || (psAckMsg->srcMsgType == AM_SBL_HOST_MSG_UPDATE_STATUS) )
+                {
+                    if (  (psAckMsg->status == AM_DEVICES_COOPER_SBL_ACK_RESP_SUCCESS) || (psAckMsg->status == AM_DEVICES_COOPER_SBL_ACK_RESP_SEQ) )
+                    {
+                        if ( gsSblUpdateState.ui32TotalPackets > 0 )
+                        {
+                            //Check if this is the last packet
+                            if ( gsSblUpdateState.ui32TotalPackets == 1 )
+                            {
+                                // Get the size of the left over data
+                                ui32dataPktSize = gsSblUpdateState.ui32DataSize % AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
+                                if (ui32dataPktSize == 0)
+                                {
+                                    ui32dataPktSize = AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
+                                }
+                            }
+                            else
+                            {
+                                ui32dataPktSize = AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
+                            }
+                            send_data(gsSblUpdateState.pHandle, (uint32_t) gsSblUpdateState.pDataBuf + (gsSblUpdateState.ui32PacketNumber * AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE),
+                                      ui32dataPktSize, gsSblUpdateState.ui32PacketNumber + 1);
+                            gsSblUpdateState.ui32TotalPackets--;
+                            // increment the packet number as we have already sent the header
+                            gsSblUpdateState.ui32PacketNumber++;
+                            ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                        }
+                        else
+                        {
+                            if ( psAckMsg->status == AM_DEVICES_COOPER_SBL_ACK_RESP_SUCCESS )
+                            {
+                                // If FW is updated successfuly, then jump to BLE image
+                                if ( gsSblUpdateState.ui32ImageType == AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_FW )
+                                {
+                                    gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_IMAGE_OK;
+                                    gsSblUpdateState.ui32CooperFWImageVersion = g_sFwImage.version;
+                                    // Not done yet
+                                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                                    // Send the command to continue to FW
+                                    send_fwContinue(gsSblUpdateState.pHandle);
+                                    // If INFO 0 or INFO 1 is updated successfully, the apply send reset
+                                }
+                                else
+                                {
+                                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_OK;
+                                }
+                            }
+                            else
+                            {
+                                am_util_stdio_printf("Update fails status = 0x%x\n", psAckMsg->status);
+                                ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        am_util_stdio_printf("Update fails status = 0x%x\n", psAckMsg->status);
+                        // We have received NACK
+                        ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                    }
+                }
+                else
+                {
+                    // Wrong Response type
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                }
+            }
+            break;
+        case AM_DEVICES_COOPER_SBL_UPDATE_STATE_IMAGE_OK:
+        {
+            // Read the "ACK/NACK" response from the IOS and check for CRC Error
+            if ( iom_slave_read(gsSblUpdateState.pHandle, (uint32_t*)gsSblUpdateState.pWorkBuf, &ui32Size) == false )
+            {
+                // Increment the Error Counter
+                gsSblUpdateState.ui32ErrorCounter++;
+                // Check if the Error has happened more than the limit
+                if ( gsSblUpdateState.ui32ErrorCounter > AM_DEVICES_COOPER_SBL_MAX_COMM_ERR_COUNT )
+                {
+                    // Return fail
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+                }
+                else
+                {
+                    // Resend the previous message
+                    send_fwContinue(gsSblUpdateState.pHandle);
+                    // Tell application that we are not done with SBL
+                    ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
+                }
+            }
+            else
+            {
+                // No CRC error and if there was one, then reset the error counter
+                if ( gsSblUpdateState.ui32ErrorCounter )
+                {
+                    gsSblUpdateState.ui32ErrorCounter = 0;
+                }
+            }
+            // Get the response status
+            psAckMsg = (am_sbl_host_msg_ack_nack_t*)(gsSblUpdateState.pWorkBuf);
+            // Save the status
+            gsSblUpdateState.ui32CooperSblStatus = psAckMsg->status;
+            if ( psAckMsg->status == AM_DEVICES_COOPER_SBL_ACK_RESP_SUCCESS )
+            {
+                // FW has gone to BLE, end the SBL driver state machine
+                ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_OK;
+            }
+            else
+            {
+                ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
+            }
+        }
+        break;
+        default:
+            // Bad state, update the state machine
+            break;
+    }
+    return ui32Ret;
+}
+
+//*****************************************************************************
+//
+//  Get cooper firmware image from local binary
+//
+//*****************************************************************************
+bool am_devices_cooper_get_FwImage(am_devices_cooper_sbl_update_data_t *pFwImage )
+{
+    if (pFwImage != NULL)
+    {
+        memcpy(&g_sFwImage, pFwImage, sizeof(am_devices_cooper_sbl_update_data_t));
+        // Get version from the firmware image
+        g_sFwImage.version = (pFwImage->pImageAddress[27] << 24) | (pFwImage->pImageAddress[26] << 16) | (pFwImage->pImageAddress[25] << 8) | (pFwImage->pImageAddress[24]);
+    }
+
+    return (pFwImage != NULL);
+}
+
+//*****************************************************************************
+//
+//  Get cooper info1 image from local binary
+//
+//*****************************************************************************
+bool am_devices_cooper_get_info1_patch(am_devices_cooper_sbl_update_data_t *pInfo1Image)
+{
+    if (pInfo1Image != NULL)
+    {
+        memcpy(&g_sInfo1PatchImage, pInfo1Image, sizeof(am_devices_cooper_sbl_update_data_t));
+    }
+
+    return (pInfo1Image != NULL);
+}
+
+//*****************************************************************************
+//
+//  Get cooper info0 image from local binary
+//
+//*****************************************************************************
+bool am_devices_cooper_get_info0_patch(am_devices_cooper_sbl_update_data_t *pInfo0Image)
+{
+    if (pInfo0Image != NULL)
+    {
+        memcpy(&g_sInfo0PatchImage, pInfo0Image, sizeof(am_devices_cooper_sbl_update_data_t));
+    }
+
+    return (pInfo0Image != NULL);
+}
+
+//*****************************************************************************
+//
+//  Reset the BLE controller and check if there's request to update
+//
+//*****************************************************************************
+uint32_t am_devices_cooper_reset_with_sbl_check(void* pHandle, am_devices_cooper_config_t* pDevConfig)
+{
+    uint32_t u32SblStatus = 0;
+    am_devices_cooper_t *pBle = (am_devices_cooper_t *)pHandle;
+    am_devices_cooper_reset();
+    am_devices_cooper_image_update_init(pHandle, pDevConfig->pNBTxnBuf);
+    u32SblStatus = AM_DEVICES_COOPER_SBL_STATUS_INIT;
+    u32SblStatus = am_devices_cooper_update_image();
+    while ( (u32SblStatus != AM_DEVICES_COOPER_SBL_STATUS_OK) && ( u32SblStatus != AM_DEVICES_COOPER_SBL_STATUS_FAIL) )
+    {
+        while (am_devices_cooper_irq_read() == 0)
+        {
+            am_hal_delay_us(50);
+        }
+        u32SblStatus = am_devices_cooper_update_image();
+    }
+    //
+    // Return the status.
+    //
+    if (u32SblStatus == AM_DEVICES_COOPER_SBL_STATUS_OK)
+    {
+        // The CS assertation duration optimization only takes effect after V1.14
+        if ( gsSblUpdateState.ui32CooperFWImageVersion < 0x10E )
+        {
+            pBle->ui32CSDuration = 300;
+        }
+        pBle->ui32Firmver = gsSblUpdateState.ui32CooperFWImageVersion;
+        // need to wait a bit to jump from SBL to Cooper application firmware
+        am_util_delay_ms(10);
+        am_util_stdio_printf("Update Done\r\n");
+        return AM_DEVICES_COOPER_STATUS_SUCCESS;
+    }
+    else
+    {
+        // free up resource that won't be used.
+        am_devices_cooper_term(pHandle);
+        am_util_stdio_printf("BLE Controller SBL Error 0x%x\r\n", u32SblStatus);
+        return u32SblStatus;
+    }
+}
+
+//*****************************************************************************
+//
+// End Doxygen group.
+//! @}
+//
+//*****************************************************************************
+

--- a/components/bluetooth/am_devices_cooper.c
+++ b/components/bluetooth/am_devices_cooper.c
@@ -50,37 +50,32 @@
 #include <string.h>
 
 #include "am_mcu_apollo.h"
-#include "am_bsp.h"
 #include "am_devices_cooper.h"
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_controller, CONFIG_LOG_DEFAULT_LEVEL);
 
 //*****************************************************************************
 //
 // Timing and configuration.
 //
 //*****************************************************************************
-#define AM_DEVICES_COOPER_TIMEOUT                 10
-#define AM_DEVICES_COOPER_RETRY_TIMES             500
-
-#define OPCODE_H2WRITE_HANDSHAKE   0x80
-#define OPCODE_H2READ_HANDSHAKE    0x04
-#define OPCODE_READ_STATUS         0x08
-
-// Set to 1 to turn on logging for SBL diagnosis
-#define SBL_DEBUG_LOG_ON           0
+#define AM_DEVICES_COOPER_SBL_SEND_WAIT_TIMEOUT        K_MSEC(1000)
 
 //*****************************************************************************
 //
-// Global state variables.
+// Global variables.
 //
 //*****************************************************************************
-am_devices_cooper_t gAmCooper[AM_DEVICES_COOPER_MAX_DEVICE_NUM];
-
-//*****************************************************************************
-//
-// Global SBL update data.
-//
-//*****************************************************************************
-am_devices_cooper_buffer(2) sLengthBytes;
+uint8_t am_devices_cooper_nvds[HCI_VSC_UPDATE_NVDS_CFG_CMD_LENGTH] =
+{
+    NVDS_PARAMETER_MAGIC_NUMBER,
+    NVDS_PARAMETER_SLEEP_ALGO_DUR,
+    NVDS_PARAMETER_LPCLK_DRIFT,
+    NVDS_PARAMETER_EXT_WAKEUP_TIME,
+    NVDS_PARAMETER_OSC_WAKEUP_TIME
+};
 
 //
 //!
@@ -96,7 +91,6 @@ static am_devices_cooper_sbl_update_data_t     g_sFwImage =
     0,
     AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_FW,
     0
-
 };
 
 //
@@ -121,351 +115,57 @@ static am_devices_cooper_sbl_update_data_t     g_sInfo1PatchImage =
     0
 };
 
+//
+//! Cooper callback
+//
+static am_devices_cooper_callback_t g_CooperCb;
 
+//
+//! Semaphore to control the SBL packet sending
+//
+static K_SEM_DEFINE(sem_sbl_send, 0, 1);
 
-
-//*****************************************************************************
 //
-// COOPER_CS (54) - COOPER Master chip select.
+//! Cooper initialization state
 //
-//*****************************************************************************
-am_hal_gpio_pincfg_t g_AM_DEVICES_COOPER_SPI_CS =
-{
-#if defined(AM_PART_APOLLO4L) || defined(APOLLO4P_BLUE_KXR)
-    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_54_NCE54,
-#else
-    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_43_NCE43,
-#endif
-    .GP.cfg_b.eGPInput             = AM_HAL_GPIO_PIN_INPUT_NONE,
-    .GP.cfg_b.eGPRdZero            = AM_HAL_GPIO_PIN_RDZERO_READPIN,
-    .GP.cfg_b.eIntDir              = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
-    .GP.cfg_b.eGPOutCfg            = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
-    .GP.cfg_b.eDriveStrength       = AM_HAL_GPIO_PIN_DRIVESTRENGTH_0P5X,
-    .GP.cfg_b.uSlewRate            = 0,
-    .GP.cfg_b.ePullup              = AM_HAL_GPIO_PIN_PULLUP_NONE,
-    .GP.cfg_b.uNCE                 = AM_HAL_GPIO_NCE_IOM4CE0,
-    .GP.cfg_b.eCEpol               = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW,
-    .GP.cfg_b.uRsvd_0              = 0,
-    .GP.cfg_b.ePowerSw             = AM_HAL_GPIO_PIN_POWERSW_NONE,
-    .GP.cfg_b.eForceInputEn        = AM_HAL_GPIO_PIN_FORCEEN_NONE,
-    .GP.cfg_b.eForceOutputEn       = AM_HAL_GPIO_PIN_FORCEEN_NONE,
-    .GP.cfg_b.uRsvd_1              = 0,
-};
-
-//*****************************************************************************
-//
-//  BLE_32M_CLK (46) - BLE 32M CLK OUT.
-//
-//*****************************************************************************
-am_hal_gpio_pincfg_t g_AM_DEVICES_COOPER_32M_CLK =
-{
-    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_46_CLKOUT_32M,
-    .GP.cfg_b.eGPInput             = AM_HAL_GPIO_PIN_INPUT_NONE,
-    .GP.cfg_b.eGPRdZero            = AM_HAL_GPIO_PIN_RDZERO_READPIN,
-    .GP.cfg_b.eIntDir              = AM_HAL_GPIO_PIN_INTDIR_NONE,
-    .GP.cfg_b.eGPOutCfg            = AM_HAL_GPIO_PIN_OUTCFG_DISABLE,
-    .GP.cfg_b.eDriveStrength       = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
-    .GP.cfg_b.uSlewRate            = 0,
-    .GP.cfg_b.ePullup              = AM_HAL_GPIO_PIN_PULLUP_NONE,
-    .GP.cfg_b.uNCE                 = 0,
-    .GP.cfg_b.eCEpol               = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW,
-    .GP.cfg_b.uRsvd_0              = 0,
-    .GP.cfg_b.ePowerSw             = AM_HAL_GPIO_PIN_POWERSW_NONE,
-    .GP.cfg_b.eForceInputEn        = AM_HAL_GPIO_PIN_FORCEEN_NONE,
-    .GP.cfg_b.eForceOutputEn       = AM_HAL_GPIO_PIN_FORCEEN_NONE,
-    .GP.cfg_b.uRsvd_1              = 0,
-};
-
-//*****************************************************************************
-//
-//  BLE_32K_CLK (45) - BLE 32K CLK OUT.
-//
-//*****************************************************************************
-am_hal_gpio_pincfg_t g_AM_DEVICES_COOPER_32K_CLK =
-{
-#if defined(AM_PART_APOLLO4L) || defined(APOLLO4P_BLUE_KXR)
-    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_4_32KHzXT,
-#else
-    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_45_32KHzXT,
-#endif
-    .GP.cfg_b.eGPInput             = AM_HAL_GPIO_PIN_INPUT_NONE,
-    .GP.cfg_b.eGPRdZero            = AM_HAL_GPIO_PIN_RDZERO_READPIN,
-    .GP.cfg_b.eIntDir              = AM_HAL_GPIO_PIN_INTDIR_NONE,
-    .GP.cfg_b.eGPOutCfg            = AM_HAL_GPIO_PIN_OUTCFG_DISABLE,
-    .GP.cfg_b.eDriveStrength       = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
-    .GP.cfg_b.uSlewRate            = 0,
-    .GP.cfg_b.ePullup              = AM_HAL_GPIO_PIN_PULLUP_NONE,
-    .GP.cfg_b.uNCE                 = 0,
-    .GP.cfg_b.eCEpol               = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW,
-    .GP.cfg_b.uRsvd_0              = 0,
-    .GP.cfg_b.ePowerSw             = AM_HAL_GPIO_PIN_POWERSW_NONE,
-    .GP.cfg_b.eForceInputEn        = AM_HAL_GPIO_PIN_FORCEEN_NONE,
-    .GP.cfg_b.eForceOutputEn       = AM_HAL_GPIO_PIN_FORCEEN_NONE,
-    .GP.cfg_b.uRsvd_1              = 0,
-};
-
-//*****************************************************************************
-//
-// BLE_CLKREQ (40) - BLE CLK request pin.
-//
-//*****************************************************************************
-am_hal_gpio_pincfg_t g_AM_DEVICES_COOPER_CLKREQ =
-{
-#if defined(AM_PART_APOLLO4L) || defined(APOLLO4P_BLUE_KXR)
-    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_52_GPIO,
-#else
-    .GP.cfg_b.uFuncSel             = AM_HAL_PIN_40_GPIO,
-#endif
-    .GP.cfg_b.eGPInput             = AM_HAL_GPIO_PIN_INPUT_ENABLE,
-    .GP.cfg_b.eGPRdZero            = AM_HAL_GPIO_PIN_RDZERO_READPIN,
-    .GP.cfg_b.eIntDir              = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
-    .GP.cfg_b.eGPOutCfg            = AM_HAL_GPIO_PIN_OUTCFG_DISABLE,
-    .GP.cfg_b.eDriveStrength       = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
-    .GP.cfg_b.uSlewRate            = 0,
-    .GP.cfg_b.ePullup              = AM_HAL_GPIO_PIN_PULLUP_NONE,
-    .GP.cfg_b.uNCE                 = 0,
-    .GP.cfg_b.eCEpol               = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW,
-    .GP.cfg_b.uRsvd_0              = 0,
-    .GP.cfg_b.ePowerSw             = AM_HAL_GPIO_PIN_POWERSW_NONE,
-    .GP.cfg_b.eForceInputEn        = AM_HAL_GPIO_PIN_FORCEEN_NONE,
-    .GP.cfg_b.eForceOutputEn       = AM_HAL_GPIO_PIN_FORCEEN_NONE,
-    .GP.cfg_b.uRsvd_1              = 0,
-};
-
-static uint32_t sbl_status = 0;
-
-//*****************************************************************************
-//
-//  Set up pins for Cooper.
-//
-//*****************************************************************************
-void
-am_devices_cooper_pins_enable(void)
-{
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_RESET_PIN, am_hal_gpio_pincfg_output);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_IRQ_PIN, am_hal_gpio_pincfg_input);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_CLKREQ_PIN, am_hal_gpio_pincfg_input);
-#if (!AM_DEVICES_COOPER_QFN_PART)
-#if !defined(AM_PART_APOLLO4L)
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SWDIO, am_hal_gpio_pincfg_output);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SWCLK, am_hal_gpio_pincfg_output);
-    am_hal_gpio_output_clear(AM_DEVICES_COOPER_SWDIO);
-    am_hal_gpio_output_clear(AM_DEVICES_COOPER_SWCLK);
-#endif
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32M_CLK, g_AM_DEVICES_COOPER_32M_CLK);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32K_CLK, g_AM_DEVICES_COOPER_32K_CLK);
-#else
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32M_OSCEN_PIN, am_hal_gpio_pincfg_output);
-    am_hal_gpio_output_set(AM_DEVICES_COOPER_32M_OSCEN_PIN);
-    am_util_stdio_printf("\nThe Cooper QFN board is attached for debug\n");
-#endif
-}
-
-//*****************************************************************************
-//
-//  Disable pins for Cooper.
-//
-//*****************************************************************************
-void
-am_devices_cooper_pins_disable(void)
-{
-    am_hal_gpio_output_clear(AM_DEVICES_COOPER_RESET_PIN);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_IRQ_PIN, am_hal_gpio_pincfg_disabled);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_CLKREQ_PIN, am_hal_gpio_pincfg_disabled);
-#if (!AM_DEVICES_COOPER_QFN_PART)
-#if !defined(AM_PART_APOLLO4L)
-    am_hal_gpio_output_clear(AM_DEVICES_COOPER_SWDIO);
-    am_hal_gpio_output_clear(AM_DEVICES_COOPER_SWCLK);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SWDIO, am_hal_gpio_pincfg_disabled);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SWCLK, am_hal_gpio_pincfg_disabled);
-#endif
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32M_CLK, am_hal_gpio_pincfg_disabled);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32K_CLK, am_hal_gpio_pincfg_disabled);
-#else
-    am_hal_gpio_output_clear(AM_DEVICES_COOPER_32M_OSCEN_PIN);
-    am_hal_gpio_pinconfig(AM_DEVICES_COOPER_32M_OSCEN_PIN, am_hal_gpio_pincfg_disabled);
-#endif
-}
+static uint32_t g_CooperInitState = 0;
 
 //*****************************************************************************
 //
 //  Initialize the BLE controller driver.
 //
 //*****************************************************************************
-uint32_t
-am_devices_cooper_init(uint32_t ui32Module, am_devices_cooper_config_t* pDevConfig, void** ppHandle, void** ppBleHandle)
+uint32_t am_devices_cooper_init(am_devices_cooper_callback_t* cb)
 {
-    void* pBleHandle;
-    am_hal_iom_config_t     stIOMCOOPERSettings;
-    uint32_t      ui32Index = 0;
-    uint32_t g_CS[AM_REG_IOM_NUM_MODULES] =
-    {
-        0, 0, 0, 0, 0, 0, 0, 0
-    };
-    // Allocate a vacant device handle
-    for ( ui32Index = 0; ui32Index < AM_DEVICES_COOPER_MAX_DEVICE_NUM; ui32Index++ )
-    {
-        if ( gAmCooper[ui32Index].bOccupied == false )
-        {
-            break;
-        }
-    }
-    if ( ui32Index == AM_DEVICES_COOPER_MAX_DEVICE_NUM )
+    uint32_t ui32Status;
+    am_devices_cooper_set_initialize_state(AM_DEVICES_COOPER_STATE_STARTUP);
+	am_devices_cooper_image_update_init();
+
+    if ((!cb) || (!cb->write) || (!cb->reset))
     {
         return AM_DEVICES_COOPER_STATUS_ERROR;
     }
-    if ( (ui32Module > AM_REG_IOM_NUM_MODULES)  || (pDevConfig == NULL) )
+
+    // Register the callback functions
+    g_CooperCb.write = cb->write;
+    g_CooperCb.reset = cb->reset;
+
+    // Start the BLE controller firmware update machine
+    ui32Status = am_devices_cooper_update_image();
+    while ((ui32Status != AM_DEVICES_COOPER_SBL_STATUS_OK) &&
+        (ui32Status != AM_DEVICES_COOPER_SBL_STATUS_FAIL))
     {
-        return AM_DEVICES_COOPER_STATUS_ERROR;
-    }
-    //
-    // Enable fault detection.
-    //
-    am_hal_fault_capture_enable();
-    stIOMCOOPERSettings.ui32ClockFreq        = COOPER_IOM_FREQ;
-    stIOMCOOPERSettings.eInterfaceMode       = AM_HAL_IOM_SPI_MODE,
-    stIOMCOOPERSettings.eSpiMode             = AM_HAL_IOM_SPI_MODE_3,
-    stIOMCOOPERSettings.ui32NBTxnBufLength   = pDevConfig->ui32NBTxnBufLength;
-    stIOMCOOPERSettings.pNBTxnBuf            = pDevConfig->pNBTxnBuf;
-    //
-    // Initialize the IOM instance.
-    // Enable power to the IOM instance.
-    // Configure the IOM for Serial operation during initialization.
-    // Enable the IOM.
-    // HAL Success return is 0
-    //
-    if (am_hal_iom_initialize(ui32Module, &pBleHandle) ||
-            am_hal_iom_power_ctrl(pBleHandle, AM_HAL_SYSCTRL_WAKE, false) ||
-            am_hal_iom_configure(pBleHandle, &stIOMCOOPERSettings) ||
-            am_hal_iom_enable(pBleHandle))
-    {
-        return AM_DEVICES_COOPER_STATUS_ERROR;
-    }
-    else
-    {
-        //
-        // Configure the IOM pins.
-        //
-
-#if (SPI_MODULE == 2) && defined(AM_BSP_GPIO_IOM2_CS)
-#undef AM_BSP_GPIO_IOM2_CS
-#define AM_BSP_GPIO_IOM2_CS  AM_DEVICES_COOPER_SPI_CS // BGA&SIP share the same CS pin(NCE72) on the QFN shiled board
-#elif (SPI_MODULE == 4) && defined(AM_BSP_GPIO_IOM4_CS)
-#undef AM_BSP_GPIO_IOM4_CS
-#define AM_BSP_GPIO_IOM4_CS  AM_DEVICES_COOPER_SPI_CS
-#endif
-        am_bsp_iom_pins_enable(ui32Module, AM_HAL_IOM_SPI_MODE);
-        am_devices_cooper_pins_enable();
-#if (!AM_DEVICES_COOPER_QFN_PART)
-        //
-        // Enable crystals for Cooper
-        //
-        am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32K_ENABLE, 0);
-
-        //
-        // Enable the 32Mnz HF XTAL clock
-        //
-
-
-        am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_KICK_START, (void *)&g_amHalMcuctrlArgBLEDefault );
-
-
-#endif
-        am_devices_cooper_reset();
-
-        gAmCooper[ui32Index].pfnCallback = NULL;
-        gAmCooper[ui32Index].pCallbackCtxt = NULL;
-        gAmCooper[ui32Index].bBusy = false;
-        gAmCooper[ui32Index].bOccupied = true;
-        gAmCooper[ui32Index].bNeedCallback = true;
-        gAmCooper[ui32Index].bDMAComplete = false;
-        gAmCooper[ui32Index].bWakingUp = false;
-        gAmCooper[ui32Index].ui32CS = g_CS[ui32Module];
-        gAmCooper[ui32Index].ui32Module = ui32Module;
-        gAmCooper[ui32Index].ui32CSDuration = 100;
-        *ppBleHandle = gAmCooper[ui32Index].pBleHandle = pBleHandle;
-        *ppHandle = (void*)&gAmCooper[ui32Index];
-        // SBL checking
-        am_devices_cooper_image_update_init(*ppHandle, pDevConfig->pNBTxnBuf);
-        sbl_status = AM_DEVICES_COOPER_SBL_STATUS_INIT;
-        sbl_status = am_devices_cooper_update_image();
-
-        while ( (sbl_status != AM_DEVICES_COOPER_SBL_STATUS_OK) &&
-                ( sbl_status != AM_DEVICES_COOPER_SBL_STATUS_FAIL) )
+        if (k_sem_take(&sem_sbl_send, AM_DEVICES_COOPER_SBL_SEND_WAIT_TIMEOUT) == 0)
         {
-            while (am_devices_cooper_irq_read() == 0)
-            {
-                am_hal_delay_us(50);
-            }
-            sbl_status = am_devices_cooper_update_image();
-        }
-        //
-        // Return the status.
-        //
-        if (sbl_status == AM_DEVICES_COOPER_SBL_STATUS_OK)
-        {
-            // The CS assertation duration optimization only takes effect after V1.14
-            if ( gsSblUpdateState.ui32CooperFWImageVersion < 0x10E )
-            {
-                gAmCooper[ui32Index].ui32CSDuration = 300;
-            }
-            gAmCooper[ui32Index].ui32Firmver = gsSblUpdateState.ui32CooperFWImageVersion;
-            // need to wait a bit to jump from SBL to Cooper application firmware
-            am_util_delay_ms(10);
-            am_util_stdio_printf("BLE Controller Init Done\r\n");
-            return AM_DEVICES_COOPER_STATUS_SUCCESS;
+            ui32Status = am_devices_cooper_update_image();
         }
         else
         {
-            // free up resource that won't be used.
-            am_devices_cooper_term(*ppHandle);
-            *ppHandle = NULL;
-            am_util_stdio_printf("BLE Controller SBL Error 0x%x\r\n", sbl_status);
-            return gsSblUpdateState.ui32CooperSblStatus;
+            return AM_DEVICES_COOPER_STATUS_TIMEOUT;
         }
-    }
-}
 
-//*****************************************************************************
-//
-//  De-Initialize the BLE controller driver.
-//
-//*****************************************************************************
-uint32_t
-am_devices_cooper_term(void* pHandle)
-{
-    am_devices_cooper_t* pBle = (am_devices_cooper_t*)pHandle;
-    if ( pBle->ui32Module > AM_REG_IOM_NUM_MODULES )
-    {
-        return AM_DEVICES_COOPER_STATUS_ERROR;
     }
-#if (!AM_DEVICES_COOPER_QFN_PART)
-    // Disable crystals
-    am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32K_DISABLE, 0);
 
-    am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_DISABLE, (void *)&g_amHalMcuctrlArgBLEDefault);
-#endif
-    // Disable the pins
-    am_bsp_iom_pins_disable(pBle->ui32Module, AM_HAL_IOM_SPI_MODE);
-    am_devices_cooper_pins_disable();
-    //
-    // Disable the IOM.
-    //
-    am_hal_iom_disable(pBle->pBleHandle);
-    //
-    // Disable power to and uninitialize the IOM instance.
-    //
-    // Clear local register values first
-    am_hal_iom_power_ctrl(pBle->pBleHandle, AM_HAL_SYSCTRL_WAKE, true);
-    am_hal_iom_power_ctrl(pBle->pBleHandle, AM_HAL_SYSCTRL_DEEPSLEEP, false);
-    am_hal_iom_uninitialize(pBle->pBleHandle);
-    // Free this device handle
-    pBle->bOccupied = false;
-    // Not in waking up state
-    pBle->bWakingUp = false;
-    //
-    // Return the status.
-    //
     return AM_DEVICES_COOPER_STATUS_SUCCESS;
 }
 
@@ -477,444 +177,28 @@ am_devices_cooper_term(void* pHandle)
 void
 am_devices_cooper_reset(void)
 {
-    am_hal_gpio_output_set(AM_DEVICES_COOPER_RESET_PIN);
-    am_util_delay_ms(20);
-    am_hal_gpio_output_clear(AM_DEVICES_COOPER_RESET_PIN);
-    am_util_delay_ms(20);
-    am_hal_gpio_output_set(AM_DEVICES_COOPER_RESET_PIN);
-    // Give some delay for the 32K clock stablization
-    am_util_delay_ms(700);
+    g_CooperCb.reset();
 }
 
 //*****************************************************************************
 //
-//  Enable the IOM bus
+// Receive a packet from the Cooper SBL.
 //
 //*****************************************************************************
-uint32_t
-am_devices_cooper_bus_enable(void* pHandle)
+void am_devices_cooper_handshake_recv(uint8_t* pBuf, uint16_t len)
 {
-    am_devices_cooper_t* pBle = (am_devices_cooper_t*)pHandle;
-    if ( pBle->bOccupied != true )
-    {
-        return AM_DEVICES_COOPER_STATUS_INVALID_OPERATION;
-    }
-    // Mark the BLE interface busy so it doesn't get used by more than one
-    // interface.
-    if (pBle->bBusy == false)
-    {
-        pBle->bBusy = true;
-    }
-    else
-    {
-        return AM_DEVICES_COOPER_STATUS_BUS_BUSY;
-    }
-    am_hal_iom_power_ctrl(pBle->pBleHandle, AM_HAL_SYSCTRL_WAKE, true);
-    am_hal_iom_enable(pBle->pBleHandle);
-    return AM_DEVICES_COOPER_STATUS_SUCCESS;
-}
-
-//*****************************************************************************
-//
-//  Disable the IOM bus
-//
-//*****************************************************************************
-uint32_t
-am_devices_cooper_bus_disable(void* pHandle)
-{
-    am_devices_cooper_t* pBle = (am_devices_cooper_t*)pHandle;
-    if ( pBle->bOccupied != true )
-    {
-        return AM_DEVICES_COOPER_STATUS_INVALID_OPERATION;
-    }
-    //
-    // Disable the IOM.
-    //
-    am_hal_iom_disable(pBle->pBleHandle);
-    //
-    // Disable power.
-    //
-    am_hal_iom_power_ctrl(pBle->pBleHandle, AM_HAL_SYSCTRL_DEEPSLEEP, true);
-    // Release the bus so someone else can use it.
-    pBle->bBusy = false;
-    return AM_DEVICES_COOPER_STATUS_SUCCESS;
-}
-
-//*****************************************************************************
-//
-//  Execute HCI blocking write to the BLE controller
-//
-//*****************************************************************************
-uint32_t
-am_devices_cooper_blocking_write(void* pHandle, uint8_t ui8Type, uint32_t* pui32Data,
-                                 uint32_t ui32NumBytes, bool bWaitReady)
-{
-    uint32_t ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_SUCCESS;
-    uint32_t ui32WaitReadyCount = 0;
-    memset(&sLengthBytes.bytes, 0, 2);
-    //
-    // Make a structure for the IOM transfer.
-    //
-    am_hal_iom_transfer_t sIOMTransfer;
-    am_devices_cooper_t *pBle = (am_devices_cooper_t *)pHandle;
-
-    if ( pBle->bWakingUp )
-    {
-        ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_CONTROLLER_NOT_READY;
-        return ui32ErrorStatus;
-    }
-
-    // Awake IOM and lock the bus
-    ui32ErrorStatus = am_devices_cooper_bus_enable(pHandle);
-    if (ui32ErrorStatus != AM_DEVICES_COOPER_STATUS_SUCCESS)
-    {
-        return ui32ErrorStatus;
-    }
-
-#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
-    sIOMTransfer.ui64Instr = OPCODE_H2WRITE_HANDSHAKE;
-#else
-    sIOMTransfer.ui32Instr = OPCODE_H2WRITE_HANDSHAKE;
-#endif
-    sIOMTransfer.ui32InstrLen = 1;
-    sIOMTransfer.eDirection = AM_HAL_IOM_RX;
-    sIOMTransfer.ui32NumBytes = 2;
-    sIOMTransfer.bContinue = true;
-    sIOMTransfer.uPeerInfo.ui32SpiChipSelect = pBle->ui32CS;
-    sIOMTransfer.pui32RxBuffer = sLengthBytes.words;
-    sIOMTransfer.ui8RepeatCount = 0;
-    sIOMTransfer.ui32PauseCondition = 0;
-    sIOMTransfer.ui32StatusSetClr = 0;
-    do
-    {
-        if (am_hal_iom_blocking_transfer(pBle->pBleHandle, &sIOMTransfer))
-        {
-            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE;
-            break;
-        }
-        // Cooper is not ready now
-        if ((sLengthBytes.bytes[0] != 0x68) || (sLengthBytes.bytes[1] != 0xA8))
-        {
-            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_CONTROLLER_NOT_READY;
-            //
-            // Cooper needs CS to low/asserted for 100us to detect wakeup request,
-            // and it takes about 2ms for Cooper to be ready to accept packet by asserting
-            // IRQ pin.
-            //
-            am_util_delay_us(pBle->ui32CSDuration);
-            // For the applications which do not enable IRQ interrupt, we need to do continuous try here
-            if ( bWaitReady )
-            {
-                //
-                // We need to set CS pin (first configured as GPIO) high to trigger Cooper to start wakeup process,
-                // after that we reconfigure CS pin back to IOM mode for next transfer.
-                //
-                am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SPI_CS, am_hal_gpio_pincfg_output);
-                am_hal_gpio_output_set(AM_DEVICES_COOPER_SPI_CS);
-
-#if (!AM_DEVICES_COOPER_QFN_PART)
-                // If the CS PIN is pulled high and then pulled low too quickly, Cooper may not be able to detect it.
-                am_util_delay_us(pBle->ui32CSDuration);
-#endif
-
-                am_hal_gpio_pinconfig(AM_DEVICES_COOPER_SPI_CS, g_AM_DEVICES_COOPER_SPI_CS);
-                am_util_delay_us(1700);
-                //
-                // One count is about 2ms, if Cooper is not available to receive HCI packets
-                // in configured timeout, need to return the error status and jump out
-                // from the infinite trying.
-                //
-                if (ui32WaitReadyCount == AM_DEVICES_COOPER_RETRY_TIMES)
-                {
-                    ui32WaitReadyCount = 0;
-                    ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_TIMEOUT;
-                    break;
-                }
-                ui32WaitReadyCount ++;
-                continue;
-            }
-            else
-            {
-                pBle->bWakingUp = true;
-                break;
-            }
-        }
-        ui32WaitReadyCount = 0;
-        //
-        // If this isn't a "raw" transaction, we need to make sure the "type" byte
-        // gets through to the interface.
-        //
-        if (ui8Type != AM_DEVICES_COOPER_RAW)
-        {
-#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
-            sIOMTransfer.ui64Instr = ui8Type;
-#else
-            sIOMTransfer.ui32Instr = ui8Type;
-#endif
-            sIOMTransfer.ui32InstrLen = 1;
-        }
-        else
-        {
-#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
-            sIOMTransfer.ui64Instr = 0;
-#else
-            sIOMTransfer.ui32Instr = 0;
-#endif
-            sIOMTransfer.ui32InstrLen = 0;
-        }
-        sIOMTransfer.eDirection = AM_HAL_IOM_TX;
-        sIOMTransfer.ui32NumBytes = ui32NumBytes;
-        sIOMTransfer.pui32TxBuffer = pui32Data;
-        sIOMTransfer.bContinue = false;
-        //
-        // If the previous step succeeded, we can go ahead and send the data.
-        //
-        ui32ErrorStatus = am_hal_iom_blocking_transfer(pBle->pBleHandle, &sIOMTransfer);
-        if (ui32ErrorStatus != AM_DEVICES_COOPER_STATUS_SUCCESS)
-        {
-            //
-            // The layer above this one doesn't understand IOM errors, so we
-            // will intercept and rename it here.
-            //
-            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE;
-            break;
-        }
-        break;
-    }
-    while (1);
-
-    // Disable IOM to save power
-    am_devices_cooper_bus_disable(pHandle);
-
-    return ui32ErrorStatus;
-}
-
-
-//*****************************************************************************
-//
-//  Execute HCI blocking read from the BLE controller
-//
-//*****************************************************************************
-uint32_t
-am_devices_cooper_blocking_read(void* pHandle, uint32_t* pui32Data,
-                                uint32_t* pui32BytesReceived)
-{
-    uint32_t ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_SUCCESS;
-    memset(&sLengthBytes.bytes, 0, 2);
-    am_devices_cooper_t* pBle = (am_devices_cooper_t*)pHandle;
-
-    // Skip if IRQ pin is low -- no pending incoimng packet from Cooper.
-    if (!am_devices_cooper_irq_read())
-    {
-        *pui32BytesReceived = 0;
-        return AM_DEVICES_COOPER_STATUS_SUCCESS;
-    }
-    //
-    // Make a structure for the IOM transfer.
-    //
-    am_hal_iom_transfer_t sIOMTransfer;
-    // Awake IOM and lock the bus
-    ui32ErrorStatus = am_devices_cooper_bus_enable(pHandle);
-    if (ui32ErrorStatus != AM_DEVICES_COOPER_STATUS_SUCCESS)
-    {
-        return ui32ErrorStatus;
-    }
-    do
-    {
-        sIOMTransfer.uPeerInfo.ui32SpiChipSelect = pBle->ui32CS;
-#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
-        sIOMTransfer.ui64Instr = OPCODE_H2READ_HANDSHAKE;
-#else
-        sIOMTransfer.ui32Instr = OPCODE_H2READ_HANDSHAKE;
-#endif
-        sIOMTransfer.ui32InstrLen = 1;
-        sIOMTransfer.eDirection = AM_HAL_IOM_RX;
-        sIOMTransfer.ui32NumBytes = 2;
-        sIOMTransfer.pui32RxBuffer = sLengthBytes.words;
-        sIOMTransfer.bContinue = true;
-        sIOMTransfer.ui8RepeatCount = 0;
-        sIOMTransfer.ui32PauseCondition = 0;
-        sIOMTransfer.ui32StatusSetClr = 0;
-        //
-        // First we should get the byte available back
-        //
-        if (am_hal_iom_blocking_transfer(pBle->pBleHandle, &sIOMTransfer))
-        {
-            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE;
-            break;
-        }
-        if ((sLengthBytes.bytes[0] == 0) && (sLengthBytes.bytes[1] == 0))
-        {
-            *pui32BytesReceived = 0;
-            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_SUCCESS;
-            break;
-        }
-        //
-        // This is the second frame of the read, which contains the actual HCI
-        // data.
-        //
-#if defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
-        sIOMTransfer.ui64Instr = 0;
-#else
-        sIOMTransfer.ui32Instr = 0;
-#endif
-        sIOMTransfer.ui32InstrLen = 0;
-        sIOMTransfer.pui32RxBuffer = pui32Data;
-        sIOMTransfer.ui32NumBytes = (sLengthBytes.bytes[0] +
-                                     (sLengthBytes.bytes[1] << 8));
-        sIOMTransfer.bContinue = false;
-        // check ui32NumBytes
-        if (sIOMTransfer.ui32NumBytes > AM_DEVICES_COOPER_MAX_RX_PACKET)
-        {
-            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_WRONG_DATA_LENGTH;
-            *pui32BytesReceived = 0;
-            break;
-        }
-        //
-        // Make sure the caller knows how many bytes we got.
-        //
-        *pui32BytesReceived = sIOMTransfer.ui32NumBytes;
-        //
-        // Execute the second part of the transfer.
-        //
-        ui32ErrorStatus = am_hal_iom_blocking_transfer(pBle->pBleHandle, &sIOMTransfer);
-        //
-        // A failure here indicates that the second part of the read was bad.
-        //
-        if (ui32ErrorStatus)
-        {
-            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE;
-            *pui32BytesReceived = 0;
-            break;
-        }
-    }
-    while (0);
-
-    // Disable IOM to save power
-    am_devices_cooper_bus_disable(pHandle);
-
-    return ui32ErrorStatus;
-}
-
-
-//*****************************************************************************
-//
-//  Send HCI raw command to the BLE controller
-//
-//*****************************************************************************
-uint32_t
-am_devices_cooper_command_write(void* pHandle, uint32_t* pui32Cmd, uint32_t ui32Length, uint32_t* pui32Response, uint32_t* pui32BytesReceived)
-{
-    uint32_t ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_SUCCESS;
-    if ( !pui32Cmd || !pui32Response || !pui32BytesReceived )
-    {
-        return AM_DEVICES_COOPER_STATUS_INVALID_OPERATION;
-    }
-    do
-    {
-        ui32ErrorStatus = am_devices_cooper_blocking_write(pHandle,
-                          AM_DEVICES_COOPER_RAW,
-                          pui32Cmd,
-                          ui32Length, true);
-        if (ui32ErrorStatus)
-        {
-            break;
-        }
-        //
-        // Wait for the response, and return it to the caller via our variable.
-        //
-        WHILE_TIMEOUT_MS ( am_devices_cooper_irq_read() == 0, 5000, ui32ErrorStatus );
-        if (ui32ErrorStatus)
-        {
-            ui32ErrorStatus = AM_DEVICES_COOPER_STATUS_NO_RESPONSE;
-            break;
-        }
-        while(1)
-        {
-            ui32ErrorStatus = am_devices_cooper_blocking_read(pHandle, pui32Response, pui32BytesReceived);
-            // Keep reading until we get the corresponding response
-            if ((ui32ErrorStatus) || ((UINT32_TO_BYTE0(pui32Response[1]) == UINT32_TO_BYTE1(pui32Cmd[0])) && (UINT32_TO_BYTE1(pui32Response[1]) == UINT32_TO_BYTE2(pui32Cmd[0]))))
-            {
-                break;
-            }
-        }
-    } while (0);
-    //
-    // Return the status.
-    //
-    return ui32ErrorStatus;
-}
-
-//*****************************************************************************
-//
-// Check the state of the IRQ pin.
-//
-//*****************************************************************************
-uint32_t
-am_devices_cooper_irq_read(void)
-{
-    return am_hal_gpio_input_read(AM_DEVICES_COOPER_IRQ_PIN);
-}
-
-//*****************************************************************************
-//
-// Check the state of the CLKREQ pin.
-//
-//*****************************************************************************
-uint32_t
-am_devices_cooper_clkreq_read(void* pHandle)
-{
-    return am_hal_gpio_input_read(AM_DEVICES_COOPER_CLKREQ_PIN);
-}
-
-//*****************************************************************************
-//
-//  Set the 32M crystal frequency based on the tested values at customer side.
-//
-//*****************************************************************************
-uint32_t
-am_devices_cooper_crystal_trim_set(void *pHandle, uint32_t ui32TrimValue)
-{
-    if ( ui32TrimValue > 0x3FF )
-    {
-        return AM_DEVICES_COOPER_STATUS_ERROR;
-    }
-
-    //
-    // XTALHSCAP2TRIM : 6;  [5..0] xtalhs_cap2_trim
-    // XTALHSCAPTRIM : 4;   [9..6] xtalhs_cap_trim
-    //
-
-    g_ui32xtalhscap2trim = (ui32TrimValue & MCUCTRL_XTALHSTRIMS_XTALHSCAP2TRIM_Msk);
-    g_ui32xtalhscaptrim  = (ui32TrimValue & MCUCTRL_XTALHSTRIMS_XTALHSCAPTRIM_Msk) >> MCUCTRL_XTALHSTRIMS_XTALHSCAPTRIM_Pos;
-
-    return AM_DEVICES_COOPER_STATUS_SUCCESS;
-}
-
-
-
-/////////////////////////////////////////////////////////////////////////////////
-//
-// SBL Driver
-//
-/////////////////////////////////////////////////////////////////////////////////
-
-//*****************************************************************************
-//
-// Read a packet from the SBL IOS.
-//
-//*****************************************************************************
-bool iom_slave_read(void* pHandle, uint32_t* pBuf, uint32_t* psize)
-{
-    am_secboot_wired_msghdr_t* msg;
+    am_sbl_host_msg_hdr_t* msg;
     uint32_t crc32;
-    am_devices_cooper_blocking_read(pHandle, pBuf, psize);
+
     // Verify the received data CRC
-    msg = (am_secboot_wired_msghdr_t*)pBuf;
-    am_hal_crc32((uint32_t)&msg->msgType, msg->length - sizeof(uint32_t), &crc32);
+    msg = (am_sbl_host_msg_hdr_t*)pBuf;
+    am_hal_crc32((uint32_t)&msg->msgType, msg->msgLength - sizeof(uint32_t), &crc32);
 
+    gsSblUpdateState.pWorkBuf = (uint32_t*)msg;
+    gsSblUpdateState.bRxCrcCheckPass = (crc32 == msg->msgCrc);
+    gsSblUpdateState.ui32RxPacketLength = len;
 
-    return (crc32 == msg->crc32);
+    k_sem_give(&sem_sbl_send);
 }
 
 //*****************************************************************************
@@ -922,17 +206,16 @@ bool iom_slave_read(void* pHandle, uint32_t* pBuf, uint32_t* psize)
 // Send a "HELLO" packet.
 //
 //*****************************************************************************
-void send_hello(void* pHandle)
+static void send_hello(void)
 {
-    am_secboot_wired_msghdr_t msg;
+    am_sbl_host_msg_hdr_t msg;
     msg.msgType = AM_SBL_HOST_MSG_HELLO;
-    msg.length = sizeof(am_secboot_wired_msghdr_t);
+    msg.msgLength = sizeof(am_sbl_host_msg_hdr_t);
     //
     // Compute CRC
     //
-    //PRT_INFO("send_hello: sending bytes: %d.\n", msg.length );
-    am_hal_crc32((uint32_t)&msg.msgType, msg.length - sizeof(uint32_t), &msg.crc32);
-    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)&msg, sizeof(msg), true);
+    am_hal_crc32((uint32_t)&msg.msgType, msg.msgLength - sizeof(uint32_t), &msg.msgCrc);
+    g_CooperCb.write((uint8_t*)&msg, sizeof(msg));
 }
 
 //*****************************************************************************
@@ -940,7 +223,7 @@ void send_hello(void* pHandle)
 // Send a "UPDATE" packet.
 //
 //*****************************************************************************
-void send_update(void* pHandle, uint32_t imgBlobSize)
+static void send_update(uint32_t imgBlobSize)
 {
     am_sbl_host_msg_update_t msg;
     msg.msgHdr.msgType = AM_SBL_HOST_MSG_UPDATE;
@@ -972,7 +255,7 @@ void send_update(void* pHandle, uint32_t imgBlobSize)
     // Compute CRC
     //
     am_hal_crc32((uint32_t)&msg.msgHdr.msgType, msg.msgHdr.msgLength - sizeof(uint32_t), &msg.msgHdr.msgCrc);
-    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)&msg, sizeof(msg), true);
+    g_CooperCb.write((uint8_t*)&msg, sizeof(msg));
 }
 
 //*****************************************************************************
@@ -980,7 +263,7 @@ void send_update(void* pHandle, uint32_t imgBlobSize)
 // Send a "Data" packet.
 //
 //*****************************************************************************
-void send_data(void* pHandle, uint32_t address, uint32_t size, uint32_t pktNumber)
+static void send_data(uint32_t address, uint32_t size, uint32_t pktNumber)
 {
     // reuse same buffer for receiving
     am_sbl_host_msg_data_t* msg = (am_sbl_host_msg_data_t*)gsSblUpdateState.pWorkBuf;
@@ -992,7 +275,7 @@ void send_data(void* pHandle, uint32_t address, uint32_t size, uint32_t pktNumbe
     // Compute CRC
     //
     am_hal_crc32((uint32_t) & (msg->msgHdr.msgType), msg->msgHdr.msgLength - sizeof(uint32_t), &msg->msgHdr.msgCrc);
-    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)msg, (sizeof(am_sbl_host_msg_data_t) + size), true);
+    g_CooperCb.write((uint8_t*)msg, (sizeof(am_sbl_host_msg_data_t) + size));
 }
 
 //*****************************************************************************
@@ -1000,7 +283,7 @@ void send_data(void* pHandle, uint32_t address, uint32_t size, uint32_t pktNumbe
 // Send a "Reset" packet.
 //
 //*****************************************************************************
-void send_reset(void* pHandle)
+void send_reset(void)
 {
     am_sbl_host_msg_reset_t msg;
     msg.msgHdr.msgType = AM_SBL_HOST_MSG_RESET;
@@ -1009,7 +292,7 @@ void send_reset(void* pHandle)
     // Compute CRC
     //
     am_hal_crc32((uint32_t)&msg.msgHdr.msgType, msg.msgHdr.msgLength - sizeof(uint32_t), &msg.msgHdr.msgCrc);
-    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)&msg, sizeof(msg), true);
+    g_CooperCb.write((uint8_t*)&msg, sizeof(msg));
 }
 
 //*****************************************************************************
@@ -1017,7 +300,7 @@ void send_reset(void* pHandle)
 // Send a "FW Continue  packet.
 //
 //*****************************************************************************
-void send_fwContinue(void* pHandle)
+static void send_fwContinue(void)
 {
     am_sbl_host_msg_fw_continue_t msg;
     msg.msgHdr.msgType = AM_SBL_HOST_MSG_FW_CONTINUE;
@@ -1026,7 +309,7 @@ void send_fwContinue(void* pHandle)
     // Compute CRC
     //
     am_hal_crc32((uint32_t)&msg.msgHdr.msgType, msg.msgHdr.msgLength - sizeof(uint32_t), &msg.msgHdr.msgCrc);
-    am_devices_cooper_blocking_write(pHandle, AM_DEVICES_COOPER_RAW, (uint32_t*)&msg, sizeof(msg), true);
+    g_CooperCb.write((uint8_t*)&msg, sizeof(msg));
 }
 
 //*****************************************************************************
@@ -1087,43 +370,30 @@ static bool am_devices_cooper_sbl_update_state_data(uint32_t ui32updateType)
 //  Initialize the Image Update state machine
 //
 //*****************************************************************************
-uint32_t am_devices_cooper_image_update_init(void* pHandle, uint32_t* pWorkBuf)
+void am_devices_cooper_image_update_init(void)
 {
-    // Check for the input data validity
-    if (pHandle != NULL)
-    {
-        // Initialize state machine
-        gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_INIT;
-        // Load the image address
-        gsSblUpdateState.pImageBuf          = NULL;
-        // Image size
-        gsSblUpdateState.ui32ImageSize      = 0;
-        // image type
-        gsSblUpdateState.ui32ImageType      = AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_NONE;
-        // Get the size of the data without headers
-        gsSblUpdateState.ui32DataSize       = 0;
-        // Get the start address of the data without headers
-        gsSblUpdateState.pDataBuf           = NULL;
-        // Calculate number of packets
-        gsSblUpdateState.ui32TotalPackets   = 0;
-        // Initialize Packet number in progress
-        gsSblUpdateState.ui32PacketNumber = 0;
-        //
-        // Save cooper device handle
-        //
-        gsSblUpdateState.pHandle = pHandle;
-        //
-        // Work buffer reuse non-blocking work buffer.
-        //
-        gsSblUpdateState.pWorkBuf = pWorkBuf;
-        // State is ready to go. Reset the cooper device
-        return 0;
-    }
-    else
-    {
-        // Return with error
-        return 1;
-    }
+    // Initialize state machine
+    gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_INIT;
+    // Load the image address
+    gsSblUpdateState.pImageBuf          = NULL;
+    // Image size
+    gsSblUpdateState.ui32ImageSize      = 0;
+    // image type
+    gsSblUpdateState.ui32ImageType      = AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_NONE;
+    // Get the size of the data without headers
+    gsSblUpdateState.ui32DataSize       = 0;
+    // Get the start address of the data without headers
+    gsSblUpdateState.pDataBuf           = NULL;
+    // Calculate number of packets
+    gsSblUpdateState.ui32TotalPackets   = 0;
+    // Initialize Packet number in progress
+    gsSblUpdateState.ui32PacketNumber   = 0;
+    // Initialize the processing buffer
+    gsSblUpdateState.pWorkBuf           = NULL;
+    // Initialize the RX CRC check result
+    gsSblUpdateState.bRxCrcCheckPass    = false;
+    // Initialzie the length of receive packet
+    gsSblUpdateState.ui32RxPacketLength = 0;
 }
 
 //*****************************************************************************
@@ -1135,7 +405,7 @@ uint32_t am_devices_cooper_image_update_init(void* pHandle, uint32_t* pWorkBuf)
 uint32_t am_devices_cooper_update_image(void)
 {
     uint32_t     ui32dataPktSize = 0;
-    uint32_t     ui32Size        = 0;
+    uint32_t     ui32Size        = gsSblUpdateState.ui32RxPacketLength;
     uint32_t     ui32Ret         = AM_DEVICES_COOPER_SBL_STATUS_INIT;
     am_sbl_host_msg_status_t*    psStatusMsg;
     am_sbl_host_msg_ack_nack_t*  psAckMsg;
@@ -1145,14 +415,14 @@ uint32_t am_devices_cooper_update_image(void)
             //
             // Send the "HELLO" message to connect to the interface.
             //
-            send_hello(gsSblUpdateState.pHandle);
+            send_hello();
             gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_HELLO;
             // Tell application that we are not done with SBL
             ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
             break;
         case AM_DEVICES_COOPER_SBL_UPDATE_STATE_HELLO:
             // Read the "STATUS" response from the IOS and check for CRC Error
-            if ( iom_slave_read(gsSblUpdateState.pHandle, (uint32_t*)gsSblUpdateState.pWorkBuf, &ui32Size) == false )
+            if ( gsSblUpdateState.bRxCrcCheckPass == false )
             {
                 // Increment the Error Counter
                 gsSblUpdateState.ui32ErrorCounter++;
@@ -1165,7 +435,7 @@ uint32_t am_devices_cooper_update_image(void)
                 else
                 {
                     // Resend the previous message
-                    send_hello(gsSblUpdateState.pHandle);
+                    send_hello();
                     // Tell application that we are not done with SBL
                     ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
                 }
@@ -1189,7 +459,7 @@ uint32_t am_devices_cooper_update_image(void)
                 {
                     gsSblUpdateState.ui32CooperFWImageVersion = psStatusMsg->versionNumber;
                 }
-                am_util_stdio_printf("BLE Controller Info:\n");
+                LOG_INF("BLE Controller Info:");
                 /*
                  * Before Cooper firmware version 1.19 (0x00000113), only the lower 16-bit of 32-bit Cooper firmware version
                  * word was used to identify Cooper firmware. It was limited to distinguish the difference of testing binaries.
@@ -1201,33 +471,31 @@ uint32_t am_devices_cooper_update_image(void)
                  */
                 if ((psStatusMsg->versionNumber & 0xFFFF0000) == 0)
                 {
-                    am_util_stdio_printf("\tFW Ver:      %d.%d\n", (psStatusMsg->versionNumber & 0xF00) >> 8, psStatusMsg->versionNumber & 0xFF);
+                    LOG_INF("\tFW Ver:      %d.%d", (psStatusMsg->versionNumber & 0xF00) >> 8, psStatusMsg->versionNumber & 0xFF);
                 }
                 else
                 {
-                    am_util_stdio_printf("\tFW Ver:      %d.%d.%d.%d\n", (psStatusMsg->versionNumber & 0xFF000000) >> 24, (psStatusMsg->versionNumber & 0xFF0000) >> 16,
+                    LOG_INF("\tFW Ver:      %d.%d.%d.%d", (psStatusMsg->versionNumber & 0xFF000000) >> 24, (psStatusMsg->versionNumber & 0xFF0000) >> 16,
                                                                         (psStatusMsg->versionNumber & 0xFF00) >> 8, psStatusMsg->versionNumber & 0xFF);
                 }
                 if (ui32Size == sizeof(am_sbl_host_msg_status_t))
                 {
                     // Get the version rollback configuration
                     gsSblUpdateState.ui32CooperVerRollBackConfig = psStatusMsg->verRollBackStatus;
-#if (SBL_DEBUG_LOG_ON == 1)
                     if ( psStatusMsg->verRollBackStatus == AM_DEVICES_COOPER_SBL_STAT_VER_ROLL_BACK_EN )
                     {
-                        am_util_stdio_printf("Version RollBack Enabled \n");
+                        LOG_DBG("Version RollBack Enabled ");
                     }
                     else if ( psStatusMsg->verRollBackStatus == AM_DEVICES_COOPER_SBL_STAT_VER_ROLL_BACK_DBL )
                     {
-                        am_util_stdio_printf("Version RollBack Disabled \n");
+                        LOG_DBG("Version RollBack Disabled ");
                     }
                     else
                     {
-                        am_util_stdio_printf("Version RollBack Config invalid !!! \n");
+                        LOG_DBG("Version RollBack Config invalid !!! ");
                     }
-#endif
-                    am_util_stdio_printf("\tChip ID0:    0x%x\n", psStatusMsg->copperChipIdWord0);
-                    am_util_stdio_printf("\tChip ID1:    0x%x\n\n", psStatusMsg->copperChipIdWord1);
+                    LOG_INF("\tChip ID0:    0x%x", psStatusMsg->copperChipIdWord0);
+                    LOG_INF("\tChip ID1:    0x%x", psStatusMsg->copperChipIdWord1);
 
                     gsSblUpdateState.ui32copperChipIdWord0 = psStatusMsg->copperChipIdWord0;
                     gsSblUpdateState.ui32copperChipIdWord1 = psStatusMsg->copperChipIdWord1;
@@ -1237,10 +505,8 @@ uint32_t am_devices_cooper_update_image(void)
                 {
                     gsSblUpdateState.ui32CooperVerRollBackConfig = 0x0;
                 }
-                #if (SBL_DEBUG_LOG_ON == 1)
-                am_util_stdio_printf("BLE Controller SBL Status:  0x%x\n", sbl_status);
-                am_util_stdio_printf("bootStatus 0x%x\n", psStatusMsg->bootStatus);
-                #endif
+                LOG_DBG("bootStatus 0x%x", psStatusMsg->bootStatus);
+
                 // check if the Boot Status is success
                 if ( psStatusMsg->bootStatus == AM_DEVICES_COOPER_SBL_STAT_RESP_SUCCESS )
                 {
@@ -1254,11 +520,11 @@ uint32_t am_devices_cooper_update_image(void)
                             ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_FW;
                             if ((g_sFwImage.version & 0xFFFF0000) == 0)
                             {
-                                am_util_stdio_printf("Received new BLE Controller FW version = %d.%d Going for upgrade\n", (g_sFwImage.version & 0xF00) >> 8, g_sFwImage.version & 0xFF);
+                                LOG_INF("Received new BLE Controller FW version = %d.%d Going for upgrade", (g_sFwImage.version & 0xF00) >> 8, g_sFwImage.version & 0xFF);
                             }
                             else
                             {
-                                am_util_stdio_printf("Received new BLE Controller FW version = %d.%d.%d.%d Going for upgrade\n", (g_sFwImage.version & 0xFF000000) >> 24, (g_sFwImage.version & 0xFF0000) >> 16,
+                                LOG_INF("Received new BLE Controller FW version = %d.%d.%d.%d Going for upgrade", (g_sFwImage.version & 0xFF000000) >> 24, (g_sFwImage.version & 0xFF0000) >> 16,
                                                                                                                             (g_sFwImage.version & 0xFF00) >> 8, g_sFwImage.version & 0xFF);
                             }
                         }
@@ -1270,15 +536,15 @@ uint32_t am_devices_cooper_update_image(void)
                         gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_IMAGE_OK;
                         // Not done yet
                         ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
-                        am_util_stdio_printf("No new image to upgrade\n");
+                        LOG_INF("No new image to upgrade");
                         // Send the command to continue to FW
-                        send_fwContinue(gsSblUpdateState.pHandle);
-                        am_util_stdio_printf("BLE Controller FW Auth Passed, Continue with FW\n");
+                        send_fwContinue();
+                        LOG_INF("BLE Controller FW Auth Passed, Continue with FW");
                     }
                 }
                 else if ( psStatusMsg->bootStatus == AM_DEVICES_COOPER_SBL_STAT_RESP_FW_UPDATE_REQ )
                 {
-                    am_util_stdio_printf("BLE Controller Requires FW\n");
+                    LOG_INF("BLE Controller Requires FW");
                     if (  am_devices_cooper_sbl_update_state_data(AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_FW) == true )
                     {
                         ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_FW;
@@ -1290,7 +556,7 @@ uint32_t am_devices_cooper_update_image(void)
                 }
                 else if ( psStatusMsg->bootStatus == AM_DEVICES_COOPER_SBL_STAT_RESP_INFO0_UPDATE_REQ )
                 {
-                    am_util_stdio_printf("BLE Controller Requires INFO 0\n");
+                    LOG_INF("BLE Controller Requires INFO 0");
                     if ( am_devices_cooper_sbl_update_state_data(AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_0) == true )
                     {
                         ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_INFO_0;
@@ -1302,7 +568,7 @@ uint32_t am_devices_cooper_update_image(void)
                 }
                 else if ( psStatusMsg->bootStatus == AM_DEVICES_COOPER_SBL_STAT_RESP_INFO1_UPDATE_REQ )
                 {
-                    am_util_stdio_printf("BLE Controller Requires INFO 1\n");
+                    LOG_INF("BLE Controller Requires INFO 1");
                     if ( am_devices_cooper_sbl_update_state_data(AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_1) == true )
                     {
                         ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_UPDATE_INFO_1;
@@ -1314,7 +580,7 @@ uint32_t am_devices_cooper_update_image(void)
                 }
                 else
                 {
-                    am_util_stdio_printf("BLE Controller Wrong Response\n");
+                    LOG_ERR("BLE Controller Wrong Response");
                     ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
                 }
             }
@@ -1333,13 +599,13 @@ uint32_t am_devices_cooper_update_image(void)
                 // Update the state machine
                 gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_UPDATE;
                 // Send the update message
-                send_update(gsSblUpdateState.pHandle, gsSblUpdateState.ui32ImageSize);
+                send_update(gsSblUpdateState.ui32ImageSize);
                 ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
             }
             break;
         case AM_DEVICES_COOPER_SBL_UPDATE_STATE_UPDATE:
             // Read the "ACK/NACK" response from the IOS and check for CRC Error
-            if ( iom_slave_read(gsSblUpdateState.pHandle, (uint32_t*)gsSblUpdateState.pWorkBuf, &ui32Size) == false )
+            if ( gsSblUpdateState.bRxCrcCheckPass == false )
             {
                 // Increment the Error Counter
                 gsSblUpdateState.ui32ErrorCounter++;
@@ -1352,7 +618,7 @@ uint32_t am_devices_cooper_update_image(void)
                 else
                 {
                     // Resend the previous message
-                    send_update(gsSblUpdateState.pHandle, gsSblUpdateState.ui32ImageSize);
+                    send_update(gsSblUpdateState.ui32ImageSize);
                     // Tell application that we are not done with SBL
                     ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
                 }
@@ -1374,16 +640,16 @@ uint32_t am_devices_cooper_update_image(void)
                     // Change the state
                     gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_DATA;
                     // Send the Encrypted image header - first 64 bytes
-                    send_data(gsSblUpdateState.pHandle, (uint32_t)gsSblUpdateState.pImageBuf,
+                    send_data((uint32_t)gsSblUpdateState.pImageBuf,
                             AM_DEVICES_COOPER_SBL_UPADTE_IMAGE_HDR_SIZE, gsSblUpdateState.ui32PacketNumber);
-                    am_util_stdio_printf("BLE controller upgrade in progress, wait...\n");
+                    LOG_INF("BLE controller upgrade in progress, wait...");
                     ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
                 }
                 else if ( (psAckMsg->msgHdr.msgType == AM_SBL_HOST_MSG_NACK) && (psAckMsg->status == AM_DEVICES_COOPER_SBL_ACK_RESP_INVALID_PARAM) )
                 {
-                    am_util_stdio_printf("Clear Cooper Signature, reset Cooper and talk with SBL again\n");
+                    LOG_INF("Clear Cooper Signature, reset Cooper and talk with SBL again");
                     // Add some delay for Cooper SBL to clear signature
-                    am_util_delay_ms(1200);
+                    k_sleep(K_MSEC(1200));
                     am_devices_cooper_reset();
                     gsSblUpdateState.pImageBuf        = NULL;
                     gsSblUpdateState.ui32ImageSize    = 0;
@@ -1394,20 +660,20 @@ uint32_t am_devices_cooper_update_image(void)
                     gsSblUpdateState.ui32PacketNumber = 0;
 
                     // Send the "HELLO" message to connect to the interface.
-                    send_hello(gsSblUpdateState.pHandle);
+                    send_hello();
                     gsSblUpdateState.ui32SblUpdateState = AM_DEVICES_COOPER_SBL_UPDATE_STATE_HELLO;
                     ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
                 }
                 else
                 {
-                    am_util_stdio_printf("Update Failed !!!\n");
+                    LOG_ERR("Update Failed !!!");
                     ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
                 }
             }
             break;
         case AM_DEVICES_COOPER_SBL_UPDATE_STATE_DATA:
             // Read the "ACK/NACK" response from the IOS.
-            if ( iom_slave_read(gsSblUpdateState.pHandle, (uint32_t*)gsSblUpdateState.pWorkBuf, &ui32Size) == false )
+            if ( gsSblUpdateState.bRxCrcCheckPass == false )
             {
                 // Increment the Error Counter
                 gsSblUpdateState.ui32ErrorCounter++;
@@ -1423,15 +689,11 @@ uint32_t am_devices_cooper_update_image(void)
                     if ( gsSblUpdateState.ui32PacketNumber == 0 )
                     {
                         // Send the Encrypted image header - first 64 bytes
-                        send_data(gsSblUpdateState.pHandle, (uint32_t)gsSblUpdateState.pImageBuf,
+                        send_data((uint32_t)gsSblUpdateState.pImageBuf,
                                   AM_DEVICES_COOPER_SBL_UPADTE_IMAGE_HDR_SIZE, gsSblUpdateState.ui32PacketNumber);
                     }
                     else
                     {
-                        // Reset the packet counters to the previous ones, to resend the packet
-                        //gsSblUpdateState.ui32TotalPackets++;
-                        // increment the packet number as we have already sent the header
-                        //gsSblUpdateState.ui32PacketNumber--;
                         //Check if this is the last packet - Increase by one as we have already decremented after TX
                         if (  (gsSblUpdateState.ui32TotalPackets + 1) == 1 )
                         {
@@ -1447,7 +709,7 @@ uint32_t am_devices_cooper_update_image(void)
                             ui32dataPktSize = AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
                         }
                         // Resend the same packet - Need to decrement the packet numbers as those are already incremented
-                        send_data(gsSblUpdateState.pHandle, (uint32_t) gsSblUpdateState.pDataBuf + ( (gsSblUpdateState.ui32PacketNumber - 1) * AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE),
+                        send_data((uint32_t) gsSblUpdateState.pDataBuf + ( (gsSblUpdateState.ui32PacketNumber - 1) * AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE),
                                   ui32dataPktSize, gsSblUpdateState.ui32PacketNumber);
                     }
                     // Tell application that we are not done with SBL
@@ -1485,7 +747,7 @@ uint32_t am_devices_cooper_update_image(void)
                             {
                                 ui32dataPktSize = AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE;
                             }
-                            send_data(gsSblUpdateState.pHandle, (uint32_t) gsSblUpdateState.pDataBuf + (gsSblUpdateState.ui32PacketNumber * AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE),
+                            send_data((uint32_t) gsSblUpdateState.pDataBuf + (gsSblUpdateState.ui32PacketNumber * AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE),
                                       ui32dataPktSize, gsSblUpdateState.ui32PacketNumber + 1);
                             gsSblUpdateState.ui32TotalPackets--;
                             // increment the packet number as we have already sent the header
@@ -1504,7 +766,7 @@ uint32_t am_devices_cooper_update_image(void)
                                     // Not done yet
                                     ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
                                     // Send the command to continue to FW
-                                    send_fwContinue(gsSblUpdateState.pHandle);
+                                    send_fwContinue();
                                     // If INFO 0 or INFO 1 is updated successfully, the apply send reset
                                 }
                                 else
@@ -1514,14 +776,14 @@ uint32_t am_devices_cooper_update_image(void)
                             }
                             else
                             {
-                                am_util_stdio_printf("Update fails status = 0x%x\n", psAckMsg->status);
+                                LOG_ERR("Update fails status = 0x%x", psAckMsg->status);
                                 ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
                             }
                         }
                     }
                     else
                     {
-                        am_util_stdio_printf("Update fails status = 0x%x\n", psAckMsg->status);
+                        LOG_ERR("Update fails status = 0x%x", psAckMsg->status);
                         // We have received NACK
                         ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_FAIL;
                     }
@@ -1536,7 +798,7 @@ uint32_t am_devices_cooper_update_image(void)
         case AM_DEVICES_COOPER_SBL_UPDATE_STATE_IMAGE_OK:
         {
             // Read the "ACK/NACK" response from the IOS and check for CRC Error
-            if ( iom_slave_read(gsSblUpdateState.pHandle, (uint32_t*)gsSblUpdateState.pWorkBuf, &ui32Size) == false )
+            if ( gsSblUpdateState.bRxCrcCheckPass == false )
             {
                 // Increment the Error Counter
                 gsSblUpdateState.ui32ErrorCounter++;
@@ -1549,7 +811,7 @@ uint32_t am_devices_cooper_update_image(void)
                 else
                 {
                     // Resend the previous message
-                    send_fwContinue(gsSblUpdateState.pHandle);
+                    send_fwContinue();
                     // Tell application that we are not done with SBL
                     ui32Ret = AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS;
                 }
@@ -1631,50 +893,66 @@ bool am_devices_cooper_get_info0_patch(am_devices_cooper_sbl_update_data_t *pInf
     return (pInfo0Image != NULL);
 }
 
+
 //*****************************************************************************
 //
 //  Reset the BLE controller and check if there's request to update
 //
 //*****************************************************************************
-uint32_t am_devices_cooper_reset_with_sbl_check(void* pHandle, am_devices_cooper_config_t* pDevConfig)
+uint32_t am_devices_cooper_reset_with_sbl_check(void)
 {
     uint32_t u32SblStatus = 0;
-    am_devices_cooper_t *pBle = (am_devices_cooper_t *)pHandle;
     am_devices_cooper_reset();
-    am_devices_cooper_image_update_init(pHandle, pDevConfig->pNBTxnBuf);
+    am_devices_cooper_set_initialize_state(AM_DEVICES_COOPER_STATE_STARTUP);
+    am_devices_cooper_image_update_init();
     u32SblStatus = AM_DEVICES_COOPER_SBL_STATUS_INIT;
     u32SblStatus = am_devices_cooper_update_image();
-    while ( (u32SblStatus != AM_DEVICES_COOPER_SBL_STATUS_OK) && ( u32SblStatus != AM_DEVICES_COOPER_SBL_STATUS_FAIL) )
+    while ((u32SblStatus != AM_DEVICES_COOPER_SBL_STATUS_OK) &&
+        (u32SblStatus != AM_DEVICES_COOPER_SBL_STATUS_FAIL))
     {
-        while (am_devices_cooper_irq_read() == 0)
+        if (k_sem_take(&sem_sbl_send, AM_DEVICES_COOPER_SBL_SEND_WAIT_TIMEOUT) == 0)
         {
-            am_hal_delay_us(50);
+            u32SblStatus = am_devices_cooper_update_image();
         }
-        u32SblStatus = am_devices_cooper_update_image();
+        else
+        {
+            return AM_DEVICES_COOPER_STATUS_TIMEOUT;
+        }
+
     }
-    //
-    // Return the status.
-    //
+
     if (u32SblStatus == AM_DEVICES_COOPER_SBL_STATUS_OK)
     {
-        // The CS assertation duration optimization only takes effect after V1.14
-        if ( gsSblUpdateState.ui32CooperFWImageVersion < 0x10E )
-        {
-            pBle->ui32CSDuration = 300;
-        }
-        pBle->ui32Firmver = gsSblUpdateState.ui32CooperFWImageVersion;
         // need to wait a bit to jump from SBL to Cooper application firmware
-        am_util_delay_ms(10);
-        am_util_stdio_printf("Update Done\r\n");
+        k_sleep(K_MSEC(10));
+        LOG_INF("Update Done");
         return AM_DEVICES_COOPER_STATUS_SUCCESS;
     }
     else
     {
-        // free up resource that won't be used.
-        am_devices_cooper_term(pHandle);
-        am_util_stdio_printf("BLE Controller SBL Error 0x%x\r\n", u32SblStatus);
+        LOG_ERR("BLE Controller SBL Error 0x%x", u32SblStatus);
         return u32SblStatus;
     }
+}
+
+//*****************************************************************************
+//
+//  Get the Cooper initialization state
+//
+//*****************************************************************************
+uint32_t am_devices_cooper_get_initialize_state(void)
+{
+    return g_CooperInitState;
+}
+
+//*****************************************************************************
+//
+//  Set the Cooper initialization state
+//
+//*****************************************************************************
+void am_devices_cooper_set_initialize_state(uint32_t state)
+{
+    g_CooperInitState = state;
 }
 
 //*****************************************************************************
@@ -1683,4 +961,3 @@ uint32_t am_devices_cooper_reset_with_sbl_check(void* pHandle, am_devices_cooper
 //! @}
 //
 //*****************************************************************************
-

--- a/components/bluetooth/am_devices_cooper.h
+++ b/components/bluetooth/am_devices_cooper.h
@@ -1,0 +1,1114 @@
+//*****************************************************************************
+//
+//! @file am_devices_cooper.h
+//!
+//! @brief An implementation of the Apollo inteface to Cooper using the IOM.
+//!
+//! @addtogroup cooper Cooper BLE Device Driver
+//! @ingroup devices
+//! @{
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Copyright (c) 2023, Ambiq Micro, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This is part of revision release_sdk_4_4_0-3c5977e664 of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+
+#ifndef AM_DEVICES_COOPER_H
+#define AM_DEVICES_COOPER_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "am_util.h"
+#include <stdlib.h>
+
+//*****************************************************************************
+//
+//! Type definitions.
+//
+//*****************************************************************************
+#define am_devices_cooper_buffer(A)                                                  \
+    union                                                                     \
+    {                                                                         \
+        uint32_t words[(A + 3) >> 2];                                         \
+        uint8_t bytes[A];                                                     \
+    }
+
+//*****************************************************************************
+//
+//! Print Errors.
+//
+//*****************************************************************************
+#define PRINT_ERRORS(x)                                                       \
+    if (x)                                                                    \
+    {                                                                         \
+        am_util_debug_printf("%s. Line %d ERROR: 0x%08x\n",                   \
+                             __FILE__, __LINE__, (x));                        \
+        while (1);                                                            \
+    }
+
+#define WHILE_TIMEOUT_MS(expr, limit, timeout)                                    \
+        {                                                                         \
+            uint32_t ui32Timeout = 0;                                             \
+            while (expr)                                                          \
+            {                                                                     \
+                if (ui32Timeout == (limit * 1000))                                \
+                {                                                                 \
+                    timeout = 1;                                                  \
+                    break;                                                        \
+                }                                                                 \
+                am_util_delay_us(1);                                              \
+                ui32Timeout++;                                                    \
+            }                                                                     \
+        }
+
+#define UINT16_TO_BYTE0(n)        ((uint8_t) (n))
+#define UINT16_TO_BYTE1(n)        ((uint8_t) ((n) >> 8))
+#define UINT32_TO_BYTE0(n)        ((uint8_t) (n))
+#define UINT32_TO_BYTE1(n)        ((uint8_t) ((n) >> 8))
+#define UINT32_TO_BYTE2(n)        ((uint8_t) ((n) >> 16))
+#define UINT32_TO_BYTE3(n)        ((uint8_t) ((n) >> 24))
+
+//
+//!
+//
+typedef enum
+{
+    AM_DEVICES_COOPER_STATUS_SUCCESS,
+    AM_DEVICES_COOPER_STATUS_ERROR,
+    //
+    //! This error occurs when an HCI read or write function is called while
+    //! another HCI communication function is already in progress.
+    //
+    AM_DEVICES_COOPER_STATUS_BUS_BUSY,
+
+    //
+    //! This error means that the MCU tried to execute an HCI write, but can not
+    //! get the space available (0xA868).
+    //! This might mean that the controller has not finished the wakeup process,
+    //! the MCU need to wait until the IRQ is asserted.
+    //
+    AM_DEVICES_COOPER_STATUS_CONTROLLER_NOT_READY,
+
+    //
+    //! Wrong length of data been read back (==0 or > 260)
+    //
+    AM_DEVICES_COOPER_STATUS_WRONG_DATA_LENGTH,
+
+    //
+    //! We are expecting an HCI response to a packet we just sent, but the BLE
+    //! core isn't asserting BLEIRQ. Its software may have crashed, and it may
+    //! need to restart.
+    //
+    AM_DEVICES_COOPER_STATUS_NO_RESPONSE,
+
+    //
+    //! The transaction ends up in error and cannot finish the HCI packet R/W
+    //
+    AM_DEVICES_COOPER_STATUS_PACKET_INCOMPLETE,
+
+    //
+    //! The CQ does not complete transaction before times out
+    //
+    AM_DEVICES_COOPER_STATUS_TIMEOUT,
+    AM_DEVICES_COOPER_STATUS_INVALID_OPERATION,
+} am_devices_cooper_status_t;
+
+#define AM_DEVICES_COOPER_QFN_PART            0
+
+#if defined(AM_DEVICES_COOPER_QFN_PART) && (AM_DEVICES_COOPER_QFN_PART > 0)
+
+#if defined(AM_PART_APOLLO4L)
+#define AM_DEVICES_COOPER_IRQ_PIN             74
+#define AM_DEVICES_COOPER_RESET_PIN           77
+#define AM_DEVICES_COOPER_CLKREQ_PIN          75
+#define AM_DEVICES_COOPER_32M_OSCEN_PIN       46
+#define AM_DEVICES_COOPER_SPI_CS              91
+#define g_AM_DEVICES_COOPER_SPI_CS            g_AM_BSP_GPIO_IOM4_CS
+#else
+#define AM_DEVICES_COOPER_IRQ_PIN             73
+#define AM_DEVICES_COOPER_RESET_PIN           57
+#define AM_DEVICES_COOPER_CLKREQ_PIN          64
+#define AM_DEVICES_COOPER_STATUS_PIN          66
+#define AM_DEVICES_COOPER_32M_OSCEN_PIN       67
+#define AM_DEVICES_COOPER_SPI_CS              72 //!< BGA&SIP share the same CS pin(NCE72) on the QFN shiled board
+#define g_AM_DEVICES_COOPER_SPI_CS            g_AM_BSP_GPIO_IOM2_CS
+#endif
+
+#else
+#define AM_DEVICES_COOPER_32M_CLK             46
+#if defined(AM_PART_APOLLO4L) || defined(APOLLO4P_BLUE_KXR)
+#define AM_DEVICES_COOPER_SPI_CS              54
+#define AM_DEVICES_COOPER_32K_CLK             4
+#define AM_DEVICES_COOPER_CLKREQ_PIN          52
+#else
+#define AM_DEVICES_COOPER_SPI_CS              43
+#define AM_DEVICES_COOPER_32K_CLK             45
+#define AM_DEVICES_COOPER_CLKREQ_PIN          40
+#endif
+
+#if defined(AM_PART_APOLLO4L) || defined(APOLLO4P_BLUE_KXR)
+
+#define AM_DEVICES_COOPER_IRQ_PIN             53
+#define AM_DEVICES_COOPER_RESET_PIN           55
+#define AM_DEVICES_COOPER_SWDIO               97
+#define AM_DEVICES_COOPER_SWCLK               98
+#else
+
+#define AM_DEVICES_COOPER_IRQ_PIN             39
+#define AM_DEVICES_COOPER_CLKACK_PIN          41
+#define AM_DEVICES_COOPER_RESET_PIN           42
+#define AM_DEVICES_COOPER_STATUS_PIN          44
+#define AM_DEVICES_COOPER_SWDIO               97
+#define AM_DEVICES_COOPER_SWCLK               98
+
+#endif
+
+#endif
+
+
+//*****************************************************************************
+//
+//! Configurable buffer sizes.
+//
+//*****************************************************************************
+#define AM_DEVICES_COOPER_MAX_TX_PACKET       524 //!<  the max packet of SBL to controller is 512 plus 12 bytes header
+#define AM_DEVICES_COOPER_MAX_RX_PACKET       258 //!<  255 data + 3 header
+
+//*****************************************************************************
+//
+//! SPI configuration.
+//
+//*****************************************************************************
+#if (AM_DEVICES_COOPER_QFN_PART)
+#if defined(AM_PART_APOLLO4L)
+#define SPI_MODULE           4
+#else
+#define SPI_MODULE           2
+#endif
+#define AM_COOPER_IRQn       GPIO0_405F_IRQn
+#define am_cooper_irq_isr    am_gpio0_405f_isr
+//
+//! we need to slow down SPI clock for fly-wire case in between
+//! Apollo3/3p/4 EB/EVBB and Cooper QFN part. 8MHz is chosen conservatively.
+//
+#define COOPER_IOM_FREQ         AM_HAL_IOM_8MHZ
+#else
+#define SPI_MODULE           4
+#define AM_COOPER_IRQn       GPIO0_203F_IRQn
+#define am_cooper_irq_isr    am_gpio0_203f_isr
+#define COOPER_IOM_FREQ         AM_HAL_IOM_24MHZ
+#endif
+
+//
+//! Take over the interrupt handler for whichever IOM we're using.
+//
+#define cooper_iom_isr                                                          \
+    am_iom_isr1(SPI_MODULE)
+#define am_iom_isr1(n)                                                        \
+    am_iom_isr(n)
+#define am_iom_isr(n)                                                         \
+    am_iomaster ## n ## _isr
+
+#define IOM_INTERRUPT1(n)       AM_HAL_INTERRUPT_IOMASTER ## n
+#define IOM_INTERRUPT(n)        IOM_INTERRUPT1(n)
+#define COOPER_IOM_IRQn         ((IRQn_Type)(IOMSTR0_IRQn + SPI_MODULE))
+
+//
+//! Definition of the tag associated to each parameters
+//
+enum PARAM_ID
+{
+    //! Local Bd Address
+    PARAM_ID_BD_ADDRESS                 = 0x01,
+    //! Device Name
+    PARAM_ID_DEVICE_NAME                = 0x02,
+    //! 32K source
+    PARAM_ID_32K_CLK_SOURCE             = 0x03,
+    //! Radio Drift
+    PARAM_ID_LPCLK_DRIFT                = 0x07,
+    //! Radio Jitter
+    PARAM_ID_LPCLK_JITTER               = 0x08,
+    //! External wake-up time
+    PARAM_ID_EXT_WAKEUP_TIME            = 0x0D,
+    //! Oscillator wake-up time
+    PARAM_ID_OSC_WAKEUP_TIME            = 0x0E,
+    //! Radio wake-up time
+    PARAM_ID_RM_WAKEUP_TIME             = 0x0F,
+    //! UART baudrate
+    PARAM_ID_UART_BAUDRATE              = 0x10,
+    //! Enable sleep mode
+    PARAM_ID_SLEEP_ENABLE               = 0x11,
+    //! Enable External Wakeup
+    PARAM_ID_EXT_WAKEUP_ENABLE          = 0x12,
+    //! SP Private Key 192
+    PARAM_ID_SP_PRIVATE_KEY_P192        = 0x13,
+    //! SP Public Key 192
+    PARAM_ID_SP_PUBLIC_KEY_P192         = 0x14,
+
+    //! Activity Move Configuration (enables/disables activity move for BLE connections and BT (e)SCO links)
+    PARAM_ID_ACTIVITY_MOVE_CONFIG       = 0x15,
+
+    //! Enable/disable scanning for extended advertising PDUs
+    PARAM_ID_SCAN_EXT_ADV               = 0x16,
+
+    //! Duration of the schedule reservation for long activities such as scan, inquiry, page, HDC advertising
+    PARAM_ID_SCHED_SCAN_DUR             = 0x17,
+
+    //! Programming delay, margin for programming the baseband in advance of each activity (in half-slots)
+    PARAM_ID_PROG_DELAY                 = 0x18,
+
+    //! Enable/disable channel assessment for BT and/or BLE
+    PARAM_ID_CH_ASS_EN                  = 0x19,
+
+    //! Synchronous links configuration
+    PARAM_ID_SYNC_CONFIG                = 0x2C,
+    //! PCM Settings
+    PARAM_ID_PCM_SETTINGS               = 0x2D,
+    //! Sleep algorithm duration
+    PARAM_ID_SLEEP_ALGO_DUR             = 0x2E,
+    //! Tracer configuration
+    PARAM_ID_TRACER_CONFIG              = 0x2F,
+
+    //! Diagport configuration
+    PARAM_ID_DIAG_BT_HW                 = 0x30,
+    //! Diagport configuration
+    PARAM_ID_DIAG_BLE_HW                = 0x31,
+    //! Diagport configuration
+    PARAM_ID_DIAG_SW                    = 0x32,
+    //! Diagport configuration
+    PARAM_ID_DIAG_DM_HW                 = 0x33,
+    //! Diagport configuration
+    PARAM_ID_DIAG_PLF                   = 0x34,
+
+    //! IDC selection (for audio demo)
+    PARAM_ID_IDCSEL_PLF                 = 0x37,
+
+    //! RSSI threshold tags
+    PARAM_ID_RSSI_HIGH_THR              = 0x3A,
+   //! RSSI threshold tags
+    PARAM_ID_RSSI_LOW_THR               = 0x3B,
+   //! RSSI threshold tags
+    PARAM_ID_RSSI_INTERF_THR            = 0x3C,
+
+    //! RF BTIPT
+    PARAM_ID_RF_BTIPT_VERSION          = 0x3E,
+   //! RF BTIPT
+   PARAM_ID_RF_BTIPT_XO_SETTING       = 0x3F,
+   //! RF BTIPT
+   PARAM_ID_RF_BTIPT_GAIN_SETTING     = 0x40,
+
+
+    PARAM_ID_BT_LINK_KEY_FIRST          = 0x60,
+    PARAM_ID_BT_LINK_KEY_LAST           = 0x67,
+
+    PARAM_ID_BLE_LINK_KEY_FIRST         = 0x70,
+    PARAM_ID_BLE_LINK_KEY_LAST          = 0x7F,
+    //! SC Private Key (Low Energy)
+    PARAM_ID_LE_PRIVATE_KEY_P256        = 0x80,
+    //! SC Public Key (Low Energy)
+    PARAM_ID_LE_PUBLIC_KEY_P256         = 0x81,
+    //! SC Debug: Used Fixed Private Key from NVDS (Low Energy)
+    PARAM_ID_LE_DBG_FIXED_P256_KEY      = 0x82,
+    //! SP Private Key (classic BT)
+    PARAM_ID_SP_PRIVATE_KEY_P256        = 0x83,
+    //! SP Public Key (classic BT)
+    PARAM_ID_SP_PUBLIC_KEY_P256         = 0x84,
+
+    //! LE Coded PHY 500 Kbps selection
+    PARAM_ID_LE_CODED_PHY_500           = 0x85,
+
+    //! Application specific
+    PARAM_ID_APP_SPECIFIC_FIRST         = 0x90,
+   //! Application specific
+   PARAM_ID_APP_SPECIFIC_LAST          = 0xAF,
+
+    //! Mesh NVDS values
+    PARAM_ID_MESH_SPECIFIC_FIRST        = 0xB0,
+   //! Mesh NVDS values
+   PARAM_ID_MESH_SPECIFIC_LAST         = 0xF0,
+};
+
+//NVDS_MAGIC_NUMBER
+#define NVDS_PARAMETER_MAGIC_NUMBER     0x4e, 0x56, 0x44, 0x53
+//! Local Bd Address
+#define NVDS_PARAMETER_BD_ADDRESS       PARAM_ID_BD_ADDRESS, 0x06, 0x06, 0x22, 0x44, 0x66, 0x88, 0x48, 0x59
+//! device name
+#define NVDS_PARAMETER_DEVICE_NAME      PARAM_ID_DEVICE_NAME, 0x06, 0x06, 0x43, 0x6F, 0x6F, 0x70, 0x65, 0x72
+#define NVDS_PARAMETER_EXT_32K_CLK_SOURCE PARAM_ID_32K_CLK_SOURCE, 0x06, 0x01, 0x01
+
+//*****************************************************************************
+//
+//! @name HCIPacketTypes.
+//! @brief
+//! @{
+//
+//*****************************************************************************
+#define AM_DEVICES_COOPER_RAW                      0x0
+#define AM_DEVICES_COOPER_CMD                      0x1
+#define AM_DEVICES_COOPER_ACL                      0x2
+#define AM_DEVICES_COOPER_EVT                      0x4
+
+//! @} HCIPacketTypes.
+
+//
+//! access types
+//
+typedef enum
+{
+    //! 8 bit access types
+    RD_8_Bit                   = 8,
+    //! 16 bit access types
+    RD_16_Bit                  = 16,
+    //! 32 bit access types
+    RD_32_Bit                  = 32
+
+}eMemAccess_type;
+
+#define HCI_VSC_CMD_HEADER_LENGTH                    4
+
+//*****************************************************************************
+//
+//! @brief Vendor Specific commands.
+//!
+//! @note Lengths are reported as "4 + <parameter length>". Each vendor-specific
+//! header is 4 bytes long. This definition allows the macro version of the
+//! length to be used in all BLE APIs.
+//
+//*****************************************************************************
+typedef enum
+{
+    HCI_VSC_RD_MEM_CMD_OPCODE                      = 0xFC01,
+    HCI_VSC_WR_MEM_CMD_OPCODE                      = 0xFC02,
+
+    HCI_VSC_ID_FLASH_CMD_OPCODE                    = 0xFC05,
+    HCI_VSC_ER_FLASH_CMD_OPCODE                    = 0xFC06,
+    HCI_VSC_WR_FLASH_CMD_OPCODE                    = 0xFC07,
+    HCI_VSC_RD_FLASH_CMD_OPCODE                    = 0xFC08,
+
+    HCI_VSC_PLF_RESET_CMD_OPCODE                   = 0xFC11,
+
+    HCI_VSC_REG_RD_CMD_OPCODE                      = 0xFC39,
+    HCI_VSC_REG_WR_CMD_OPCODE                      = 0xFC3A,
+
+    //! Ambiq Vendor Specific Command set Tx power level
+    HCI_VSC_SET_TX_POWER_LEVEL_CFG_CMD_OPCODE      = 0xFC70,
+    //! Ambiq Vendor Specific Command  start transmitter test
+    HCI_VSC_START_TRANS_TEST_CFG_CMD_OPCODE        = 0xFC71,
+    //! Ambiq Vendor Specific Command end transmitter test
+    HCI_VSC_END_TRANS_TEST_CFG_CMD_OPCODE          = 0xFC72,
+    //! Ambiq Vendor Specific Command set debug log bitmap
+    HCI_VSC_SET_LOG_BITMAP_CFG_CMD_OPCODE          = 0xFC73,
+    //! Ambiq Vendor Specific Command update bd address
+    HCI_VSC_SET_BD_ADDR_CFG_CMD_OPCODE             = 0xFC74,
+    //! Ambiq Vendor Specific Command update FW
+    HCI_VSC_UPDATE_FW_CFG_CMD_OPCODE               = 0xFC75,
+    //! Ambiq Vendor Specific Command get device ID
+    HCI_VSC_GET_DEVICE_ID_CFG_CMD_OPCODE           = 0xFC76,
+    //! Ambiq Vendor Specific Command set NVDS parameters
+    HCI_VSC_UPDATE_NVDS_CFG_CMD_OPCODE             = 0xFC77,
+    //! Ambiq Vendor Specific Command set link layer features
+    HCI_VSC_UPDATE_LL_FEATURE_CFG_CMD_OPCODE       = 0xFC78,
+    //! Ambiq Vendor Specific Command get RSSI in DTM mode
+    HCI_VSC_GET_DTM_RSSI_CMD_OPCODE                = 0xFC79,
+    //! Ambiq Vendor Specific Command configure specified event mask
+    HCI_VSC_CFG_EVT_MASK_CMD_OPCODE                = 0xFC7A,
+
+    // SBL use only
+    //! Ambiq Vendor Specific Command store info0 trim values to RAM
+    HCI_VSC_STORE_INFO0_TRIM_CMD_OPCODE            = 0xFCC0,
+    //! Ambiq Vendor Specific Command flash info0 trim values to cooper
+    HCI_VSC_FLASH_INFO0_TRIM_CMD_OPCODE            = 0xFCC1,
+    //! Ambiq Vendor Specific Command trigger Apollo4B to enter sleep
+    HCI_VSC_ENTER_SLEEP_CMD_OPCODE                 = 0xFCC2,
+}vsc_opcode;
+
+#define HCI_VSC_RD_MEM_CMD_LENGTH                      6
+#define HCI_VSC_WR_MEM_CMD_LENGTH                      134
+#define HCI_VSC_ID_FLASH_CMD_LENGTH                    0
+#define HCI_VSC_ER_FLASH_CMD_LENGTH                    9
+#define HCI_VSC_WR_FLASH_CMD_LENGTH                    134
+#define HCI_VSC_RD_FLASH_CMD_LENGTH                    6
+#define HCI_VSC_PLF_RESET_CMD_LENGTH                   1
+#define HCI_VSC_REG_RD_CMD_LENGTH                      4
+#define HCI_VSC_REG_WR_CMD_LENGTH                      8
+#define HCI_VSC_SET_TX_POWER_LEVEL_CFG_CMD_LENGTH      1
+#define HCI_VSC_START_TRANS_TEST_CFG_CMD_LENGTH        4
+#define HCI_VSC_END_TRANS_TEST_CFG_CMD_LENGTH          0
+#define HCI_VSC_SET_LOG_BITMAP_CFG_CMD_LENGTH          4
+#define HCI_VSC_SET_BD_ADDR_CFG_CMD_LENGTH             6
+#define HCI_VSC_UPDATE_FW_CFG_CMD_LENGTH               4
+#define HCI_VSC_GET_DEVICE_ID_CFG_CMD_LENGTH           0
+#define HCI_VSC_UPDATE_NVDS_CFG_CMD_LENGTH             240
+#define HCI_VSC_STORE_INFO0_TRIM_CMD_LENGTH            6
+#define HCI_VSC_FLASH_INFO0_TRIM_CMD_LENGTH            0
+#define HCI_VSC_ENTER_SLEEP_CMD_LENGTH                 0
+#define HCI_VSC_GET_DTM_RSSI_CMD_LENGTH                0
+#define HCI_VSC_CFG_EVT_MASK_CMD_LENGTH                4
+
+#define HCI_VSC_CMD_LENGTH(n)                          (HCI_VSC_CMD_HEADER_LENGTH + n)
+#define HCI_VSC_UPDATE_NVDS_CFG_CMD_OFFSET             (HCI_VSC_CMD_HEADER_LENGTH + 4) //!< NVDS_PARAMETER_MAGIC_NUMBER
+
+#define HCI_VSC_CMD(CMD, ...)                          {AM_DEVICES_COOPER_CMD, UINT16_TO_BYTE0(CMD##_CMD_OPCODE), UINT16_TO_BYTE1(CMD##_CMD_OPCODE), CMD##_CMD_LENGTH, ##__VA_ARGS__}
+#define HCI_RAW_CMD(OPCODE, LEN, ...)                  {AM_DEVICES_COOPER_CMD, UINT16_TO_BYTE0(OPCODE), UINT16_TO_BYTE1(OPCODE), LEN, ##__VA_ARGS__}
+
+#ifndef LPCLK_DRIFT_VALUE
+//! Radio Drift
+#define LPCLK_DRIFT_VALUE               500 //!<  PPM
+#endif
+#define NVDS_PARAMETER_LPCLK_DRIFT      PARAM_ID_LPCLK_DRIFT, 0x06, 0x2, UINT16_TO_BYTE0(LPCLK_DRIFT_VALUE), UINT16_TO_BYTE1(LPCLK_DRIFT_VALUE)
+
+#ifndef EXT_WAKEUP_TIME_VALUE
+//! External wake-up time
+#define EXT_WAKEUP_TIME_VALUE           1000 //!<  microsecond
+#endif
+#define NVDS_PARAMETER_EXT_WAKEUP_TIME  PARAM_ID_EXT_WAKEUP_TIME, 0x06, 0x02, UINT16_TO_BYTE0(EXT_WAKEUP_TIME_VALUE), UINT16_TO_BYTE1(EXT_WAKEUP_TIME_VALUE)
+#ifndef OSC_WAKEUP_TIME_VALUE
+//! Oscillator wake-up time
+#define OSC_WAKEUP_TIME_VALUE           1000 //!<  microsecond
+#endif
+#define NVDS_PARAMETER_OSC_WAKEUP_TIME  PARAM_ID_OSC_WAKEUP_TIME, 0x06, 0x02, UINT16_TO_BYTE0(OSC_WAKEUP_TIME_VALUE), UINT16_TO_BYTE1(OSC_WAKEUP_TIME_VALUE)
+//! Radio wake-up time
+#define NVDS_PARAMETER_RM_WAKEUP_TIME   PARAM_ID_RM_WAKEUP_TIME, 0x06, 0x02, 0x1E, 0x00
+//! set UART_BAUDRATE
+#define NVDS_PARAMETER_UART_BAUDRATE    PARAM_ID_UART_BAUDRATE, 0x06, 0x04, 0x00, 0x10, 0x0E, 0x00
+//! sleep algorithm enabled
+#define NVDS_PARAMETER_SLEEP_ENABLE     PARAM_ID_SLEEP_ENABLE, 0x06, 0x01, 0x01
+//! sleep algorithm disabled
+#define NVDS_PARAMETER_SLEEP_DISABLE    PARAM_ID_SLEEP_ENABLE, 0x06, 0x01, 0x00
+//! external wake-up support
+#define NVDS_PARAMETER_EXT_WAKEUP_ENABLE PARAM_ID_EXT_WAKEUP_ENABLE, 0x06, 0x01, 0x01
+//! Activity Move Configuration
+#define NVDS_PARAMETER_ACTIVITY_MOVE_CONFIG PARAM_ID_ACTIVITY_MOVE_CONFIG, 0x06, 0x01, 0x01
+//! Enable/disable scanning for extended advertising PDUs
+#define NVDS_PARAMETER_SCAN_EXT_ADV      PARAM_ID_SCAN_EXT_ADV, 0x06, 0x01, 0x01
+//! default scan duration
+#define NVDS_PARAMETER_SCHED_SCAN_DUR    PARAM_ID_SCHED_SCAN_DUR, 0x06, 0x02, 0xE4, 0x57
+//! Programming delay
+#define NVDS_PARAMETER_PROG_DELAY        PARAM_ID_PROG_DELAY, 0x06, 0x01, 0x1
+//! channel assessment for BT and/or BLE
+#define NVDS_PARAMETER_CH_ASS_EN         PARAM_ID_CH_ASS_EN, 0x06, 0x01, 0x1
+//! sleep algorithm duration
+#define NVDS_PARAMETER_SLEEP_ALGO_DUR   PARAM_ID_SLEEP_ALGO_DUR, 0x06, 0x02, 0xF4, 0x01
+//! debug trace config
+#define NVDS_PARAMETER_TRACE_CONFIG     PARAM_ID_TRACER_CONFIG, 0x06, 0x04, 0x00, 0x00, 0x00, 0x00
+//! diagnostic port
+#define NVDS_PARAMETER_DIAG_BLE_HW      PARAM_ID_DIAG_BLE_HW, 0x06, 0x04, 0x00, 0x00, 0x00, 0x00
+//! SW diags configuration
+#define NVDS_PARAMETER_DIAG_SW          PARAM_ID_DIAG_SW, 0x06, 0x04, 0xFF, 0xFF, 0xFF, 0xFF
+//! diagport configuration
+#define NVDS_PARAMETER_DIAG_DM_HW       PARAM_ID_DIAG_DM_HW, 0x06, 0x04, 0x00, 0x00, 0x00, 0x00
+//! SC Private Key (Low Energy)
+#define NVDS_PARAMETER_LE_PRIVATE_KEY_P256   PARAM_ID_LE_PRIVATE_KEY_P256, 0x06, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+                                                                           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+                                                                           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+//! SC Debug: Used Fixed Private Key from NVDS (Low Energy)
+#define NVDS_PARAMETER_LE_DBG_FIXED_P256_KEY  PARAM_ID_LE_DBG_FIXED_P256_KEY, 0x06, 0x01, 0x00
+//! LE Coded PHY 500 Kbps selection
+#define NVDS_PARAMETER_LE_CODED_PHY_500   PARAM_ID_LE_CODED_PHY_500, 0x06, 0x01, 0x00
+
+//*****************************************************************************
+//
+//! SBL Defines
+//
+//*****************************************************************************
+#define USE_SPI_PIN                     19
+
+//
+//! Slave interrupt pin is connected here
+//
+#define BOOTLOADER_HANDSHAKE_PIN        42
+
+//
+//! This pin is connected to RESET pin of slave
+//
+#define DRIVE_SLAVE_RESET_PIN           17
+
+//
+//! This pin is connected to the 'Override' pin of slave
+//
+#define DRIVE_SLAVE_OVERRIDE_PIN        4
+
+#define AM_DEVICES_COOPER_SBL_UPDATE_STATE_INIT                     0x00
+#define AM_DEVICES_COOPER_SBL_UPDATE_STATE_HELLO                    0x01
+#define AM_DEVICES_COOPER_SBL_UPDATE_STATE_UPDATE                   0x02
+#define AM_DEVICES_COOPER_SBL_UPDATE_STATE_DATA                     0x03
+#define AM_DEVICES_COOPER_SBL_UPDATE_STATE_IMAGE_OK                 0x04
+
+#define AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_FW                  0x00
+#define AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_0              0x01
+#define AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_INFO_1              0x02
+#define AM_DEVICES_COOPER_SBL_UPDATE_IMAGE_TYPE_NONE                0x03
+
+#define AM_DEVICES_COOPER_SBL_UPADTE_MAX_SPI_PKT_SIZE               0x200
+#define AM_DEVICES_COOPER_SBL_UPADTE_INVALID_PSI_PKT_SIZE           0xFFFFFFFF
+#define AM_DEVICES_COOPER_SBL_UPADTE_IMAGE_HDR_SIZE                 0x40
+
+#define AM_DEVICES_COOPER_SBL_MAX_COMM_ERR_COUNT                    0x03
+
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_SUCCESS                      0x00
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_FAIL                         0x01
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_BAD_HDR                      0x02
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_BAD_CRC                      0x03
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_VERSION_INVALID              0x04
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_MSG_TOO_BIG                  0x05
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_UNKNOWN_MSG                  0x06
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_INVALID_ADDRESS              0x07
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_INVALID_OPERATION            0x08
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_INVALID_PARAM                0x09
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_INVALID_DATA_LEN             0x0A
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_SEQ                          0x0B
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_TOO_BIG_DATA                 0x0C
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_BAD_IMAGE                    0x0D
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_FLASH_WRITE_FAILED           0x0E
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_INVALID_DEVICE_ID            0x0F
+#define AM_DEVICES_COOPER_SBL_ACK_RESP_BAD_KEY                      0x10
+
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_SUCCESS                     0x00
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_FAIL                        0x01
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_BAD_HDR                     0x02
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_BAD_CRC                     0x03
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_STAT_BAD_SBL                0x04
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_BAD_IMAGE                   0x05
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_UNKNOWN_MSG                 0x06
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_FW_UPDATE_REQ               0x07
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_INFO0_UPDATE_REQ            0x08
+#define AM_DEVICES_COOPER_SBL_STAT_RESP_INFO1_UPDATE_REQ            0x09
+
+#define AM_DEVICES_COOPER_SBL_STATUS_INIT                           0x00000000
+#define AM_DEVICES_COOPER_SBL_STATUS_OK                             0xA5A5A5A5
+#define AM_DEVICES_COOPER_SBL_STATUS_FAIL                           0xA1A1A1A1
+#define AM_DEVICES_COOPER_SBL_STATUS_CRC_FAIL                       0xA2A2A2A2
+#define AM_DEVICES_COOPER_SBL_STATUS_UPDATE_FW                      0x4598F231
+#define AM_DEVICES_COOPER_SBL_STATUS_UPDATE_INFO_0                  0x8730DA5B
+#define AM_DEVICES_COOPER_SBL_STATUS_UPDATE_INFO_1                  0x09FA3725
+#define AM_DEVICES_COOPER_SBL_STATUS_IN_PROGRESS                    0xA78BD32C
+#define AM_DEVICES_COOPER_SBL_STATUS_UPDATE_IMAGE_FAIL              0xA3A3A3A3
+
+#define AM_DEVICES_COOPER_SBL_DEFAULT_FW_VERSION                    0xFFFFFFFF
+
+#define AM_DEVICES_COOPER_SBL_STAT_VER_ROLL_BACK_EN                 0xFFFFFFFF
+#define AM_DEVICES_COOPER_SBL_STAT_VER_ROLL_BACK_DBL                0xFFFFFF00
+
+#define AM_DEVICES_COOPER_SBL_FW_IMAGE_ADDRESS                      0x10030000
+#define AM_DEVICES_COOPER_SBL_FW_IMAGE_SIZE                         0x22890
+#define AM_DEVICES_COOPER_SBL_FW_IMAGE_SIZE_MAX                     0x30000
+
+#define AM_DEVICES_COOPER_SBL_INFO0_PATCH_ADDRESS                   AM_DEVICES_COOPER_SBL_FW_IMAGE_ADDRESS +  AM_DEVICES_COOPER_SBL_FW_IMAGE_SIZE_MAX
+#define AM_DEVICES_COOPER_SBL_INFO0_PATCH_SIZE                      0x180
+#define AM_DEVICES_COOPER_SBL_INFO0_PATCH_SIZE_MAX                  0x200
+
+#define AM_DEVICES_COOPER_SBL_INFO1_PATCH_ADDRESS                   AM_DEVICES_COOPER_SBL_INFO0_PATCH_ADDRESS +  AM_DEVICES_COOPER_SBL_INFO0_PATCH_SIZE_MAX
+#define AM_DEVICES_COOPER_SBL_INFO1_PATCH_SIZE                      0x80
+#define AM_DEVICES_COOPER_SBL_INFO1_PATCH_SIZE_MAX                  0x100
+
+//! Signatures for the image downloads
+#define COOPER_INFO0_UPDATE_SIGN   0xB35D18C9
+//! Signatures for the image downloads
+#define COOPER_INFO1_UPDATE_SIGN   0x38B75A0D
+//! Signatures for the image downloads
+#define COOPER_FW_UPDATE_SIGN      0xC593876A
+
+//
+//!
+//
+typedef struct
+{
+    uint8_t*    pImageAddress;
+    uint32_t    imageSize;
+    uint32_t    imageType;
+    uint32_t    version;
+} am_devices_cooper_sbl_update_data_t;
+
+
+//
+//!
+//
+typedef struct
+{
+    uint32_t    ui32SblUpdateState;
+    uint8_t*    pImageBuf;
+    uint32_t    ui32ImageSize;
+    uint8_t*    pDataBuf;
+    uint32_t    ui32DataSize;
+    uint32_t    ui32PacketNumber;
+    uint32_t    ui32TotalPackets;
+    uint32_t    ui32ImageType;
+    uint32_t    ui32ErrorCounter;
+    void*       pHandle; // cooper_device handle
+    uint32_t*   pWorkBuf;
+
+    uint32_t    ui32CooperFWImageVersion;
+    uint32_t    ui32CooperSblStatus;
+    uint32_t    ui32CooperVerRollBackConfig; //Version 2
+    uint32_t    ui32copperChipIdWord0;  //Version 2
+    uint32_t    ui32copperChipIdWord1;  //Version 2
+} am_devices_cooper_sbl_update_state_t;
+
+//
+//!
+//
+typedef struct
+{
+    uint32_t                     crc32;   //!< First word
+    uint16_t                     msgType; //!< am_secboot_wired_msgtype_e
+    uint16_t                     length;
+} am_secboot_wired_msghdr_t;
+
+
+//
+//!
+//
+typedef struct
+{
+    uint32_t                      length  : 16;
+    uint32_t                      resv    : 14;
+    uint32_t                      bEnd    : 1;
+    uint32_t                      bStart  : 1;
+} am_secboot_ios_pkthdr_t;
+
+
+//
+//! Message types
+//
+typedef enum
+{
+    AM_SBL_HOST_MSG_HELLO = 0,
+    AM_SBL_HOST_MSG_STATUS,
+    AM_SBL_HOST_MSG_UPDATE_STATUS,
+    AM_SBL_HOST_MSG_UPDATE,
+    AM_SBL_HOST_MSG_FW_CONTINUE,
+    AM_SBL_HOST_MSG_NACK,
+    AM_SBL_HOST_MSG_RESET,
+    AM_SBL_HOST_MSG_ACK,
+    AM_SBL_HOST_MSG_DATA
+} AM_SBL_HOST_MSG_E;
+
+//////////////////SBL Messages To and From Host////////////////////////
+
+//
+//! Message header
+//
+typedef struct
+{
+    uint32_t    msgCrc;
+    uint16_t    msgType;
+    uint16_t    msgLength;
+} am_sbl_host_msg_hdr_t;
+
+//
+//! Hello Message
+//
+typedef struct
+{
+    am_sbl_host_msg_hdr_t    msgHdr;
+} am_sbl_host_msg_hello_t;
+
+//
+//! Status message
+//
+typedef struct
+{
+    am_sbl_host_msg_hdr_t   msgHdr;
+    uint32_t                versionNumber;
+    uint32_t                maxImageSize;
+    uint32_t                bootStatus;
+    uint32_t                verRollBackStatus;  //!< Version 2
+    uint32_t                copperChipIdWord0;  //!< Version 2
+    uint32_t                copperChipIdWord1;  //!< Version 2
+} am_sbl_host_msg_status_t;
+
+//
+//! Update Message
+//
+typedef struct
+{
+    am_sbl_host_msg_hdr_t   msgHdr;
+    uint32_t                imageSize;
+    uint32_t                maxPacketSize;
+    uint32_t                NumPackets;
+    uint32_t                versionNumber;
+} am_sbl_host_msg_update_t;
+
+//
+//! Data Message
+//
+typedef struct
+{
+    am_sbl_host_msg_hdr_t   msgHdr;
+    uint32_t                packetNumber;
+    uint8_t                 data[];
+} am_sbl_host_msg_data_t;
+
+//
+//! FW continue Message
+//
+typedef struct
+{
+    am_sbl_host_msg_hdr_t   msgHdr;
+    uint32_t                reserved;
+} am_sbl_host_msg_fw_continue_t;
+//
+//! Reset Message
+//
+typedef struct
+{
+    am_sbl_host_msg_hdr_t   msgHdr;
+    uint32_t                reserved;
+} am_sbl_host_msg_reset_t;
+
+//
+//! Ack /Nack Message
+//
+typedef struct
+{
+    am_sbl_host_msg_hdr_t   msgHdr;
+    uint32_t                srcMsgType;
+    uint32_t                status;
+    uint32_t                nextPacketNum;  //!< only valid for data messages ack
+    uint32_t                reserved[3];    //!< Version 2
+} am_sbl_host_msg_ack_nack_t;
+
+
+#define   AM_DEVICES_COOPER_SBL_MAX_INFO_0_PATCH_VALUES         64
+#define   AM_DEVICES_COOPER_SBL_BIT_MASK_PER_WORD               16
+#define   AM_DEVICES_COOPER_SBL_INFO_0_REPLACE_TRIM        0x00000003
+//
+//! INFO 0 patch for Rev A only
+//
+typedef struct
+{
+    uint32_t    magicNumNSize;            //!<  0x0A500180
+    uint32_t    rsaSize;                  //!<  0x00000000
+    uint32_t    loadHdrReserved[14];      //!<  All Zeros
+    uint32_t    cmacHash[4];              //!<  All Zeros
+    uint32_t    authKeyNHashDataSize;     //!<  All Zeros
+    uint32_t    xBlock;                   //!<  0x00000000
+    uint32_t    keyDervData[4];           //!<  All Zeros
+
+    uint32_t    bitMaskWord[4];
+    uint32_t    reserved_0;
+    uint32_t    trimDataWords[AM_DEVICES_COOPER_SBL_MAX_INFO_0_PATCH_VALUES];
+    uint32_t    reserved_1;
+
+} am_sbl_info0_patch_blob_t;
+
+//
+//! INFO 0 patch data
+//
+typedef struct
+{
+    uint32_t    wordOffset;
+    uint32_t    value;
+} am_sbl_info0_patch_data_t;
+
+//*****************************************************************************
+//
+//! @brief Update Image
+//! @return uint32_t
+//
+//*****************************************************************************
+uint32_t am_devices_cooper_update_image(void);
+
+//*****************************************************************************
+//
+//! @brief Initialize the Image Update state machine
+//! @param pHandle
+//! @param pWorkbuf
+//! @return 0 is success
+//
+//*****************************************************************************
+uint32_t am_devices_cooper_image_update_init(void* pHandle, uint32_t* pWorkbuf);
+
+//*****************************************************************************
+//
+//! @brief Get cooper firmware image from local binary
+//!
+//! @param pFwImage
+//!
+//! @return true if pFwImage isn't null
+//
+//*****************************************************************************
+bool am_devices_cooper_get_FwImage(am_devices_cooper_sbl_update_data_t *pFwImage );
+
+//*****************************************************************************
+//
+//! @brief Get cooper info1 image from local binary
+//!
+//! @param pInfo1Image
+//!
+//! @return true if pInfo1Image isn't null
+//
+//*****************************************************************************
+bool am_devices_cooper_get_info1_patch(am_devices_cooper_sbl_update_data_t *pInfo1Image);
+
+//*****************************************************************************
+//
+//! @brief Get cooper info0 image from local binary
+//!
+//! @param pInfo0Image
+//!
+//! @return true if  pInfo0Image isn't null
+//
+//*****************************************************************************
+bool am_devices_cooper_get_info0_patch(am_devices_cooper_sbl_update_data_t *pInfo0Image);
+
+//
+//!
+//
+typedef struct
+{
+    uint32_t* pNBTxnBuf;
+    uint32_t ui32NBTxnBufLength;
+} am_devices_cooper_config_t;
+
+//
+//!
+//
+typedef void (*am_devices_cooper_callback_t)(void* pCallbackCtxt);
+
+//
+//!
+//
+typedef struct
+{
+    uint32_t                     ui32Module;
+    uint32_t                     ui32CS;
+    uint32_t                     ui32CSDuration;
+    uint32_t                     ui32Firmver;
+    am_devices_cooper_callback_t pfnCallback;
+    void*                        pCallbackCtxt;
+    void*                        pBleHandle;
+    bool                         bOccupied;
+    bool                         bBusy;
+    bool                         bNeedCallback;
+    volatile bool                bDMAComplete;
+    bool                         bWakingUp;
+} am_devices_cooper_t;
+
+//
+//!
+//
+#define AM_DEVICES_COOPER_MAX_DEVICE_NUM 1
+
+//*****************************************************************************
+//
+//! @brief Set up pins for Cooper.
+//!
+//! This function configures SPI, IRQ, SCK pins for Cooper
+//
+//*****************************************************************************
+extern void am_devices_cooper_pins_enable(void);
+
+//*****************************************************************************
+//
+//! @brief Disable pins for Cooper.
+//!
+//! This function configures SPI, IRQ, SCK pins for Cooper
+//
+//*****************************************************************************
+extern void am_devices_cooper_pins_disable(void);
+
+//*****************************************************************************
+//
+//! @brief Initialize the BLE controller driver.
+//!
+//! @param ui32Module   - BLE Controller Module#
+//! @param pDevConfig   - BLE Controller device structure describing the target.
+//! @param ppHandle     - BLE Controller device state structure.
+//! @param ppBleHandle  - BLE Controller device handler.
+//!
+//! @note This function should be called before any other am_devices_cooper
+//! functions. It is used to set tell the other functions how to communicate
+//! with the BLE controller hardware.
+//!
+//! @return Status.
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_init(uint32_t ui32Module, am_devices_cooper_config_t* pDevConfig, void** ppHandle, void** ppBleHandle);
+
+//*****************************************************************************
+//
+//! @brief De-Initialize the BLE controller driver.
+//!
+//! @param pHandle  - BLE Controller device handler.
+//!
+//! This function reverses the initialization
+//!
+//! @return Status.
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_term(void* pHandle);
+
+//*****************************************************************************
+//
+//! @brief Reset BLE Controller.
+//!
+//! This function asserts reset pin to reset the BLE controller
+//
+//*****************************************************************************
+extern void am_devices_cooper_reset(void);
+
+//*****************************************************************************
+//
+//! @brief Enable the IOM bus
+//!
+//! This function enables IOM module before any HCI operation take effect
+//!
+//! @param pHandle  - BLE Controller device handler.
+//!
+//! @return Status.
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_bus_enable(void* pHandle);
+
+//*****************************************************************************
+//
+//! @brief Disable the IOM bus
+//!
+//! This function disables IOM module after HCI operation done to save power
+//!
+//! @param pHandle  - BLE Controller device handler.
+//!
+//! @return Status.
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_bus_disable(void* pHandle);
+
+//*****************************************************************************
+//
+//! @brief Execute HCI blocking read from the BLE controller
+//!
+//! @param pHandle      - BLE Controller device handler.
+//! @param pui32Data    - Buffer to store the received data from the BLE controller
+//! @param pui32BytesReceived - Actually received number of bytes
+//!
+//! @return 32-bit status
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_blocking_read(void* pHandle, uint32_t* pui32Data, uint32_t* pui32BytesReceived);
+
+//*****************************************************************************
+//
+//! @brief Execute HCI blocking write to the BLE controller
+//!
+//! @param pHandle      - BLE Controller device handler.
+//! @param ui8Type      - HCI packet type.
+//! @param pui32Data    - Buffer to write the data from
+//! @param ui32NumBytes - Number of bytes to write
+//! @param bWaitReady
+//!     - True  means need to loop for the controller ready,
+//!     - False will return and wait for the IRQ interrupt
+//!
+//! @return 32-bit status
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_blocking_write(void* pHandle, uint8_t ui8Type, uint32_t* pui32Data, uint32_t ui32NumBytes, bool bWaitReady);
+
+//*****************************************************************************
+//
+//! @brief Send HCI raw command to the BLE controller
+//! @note This function should only be used in non-IRQ-interrupt mode, and
+//!        used to to send raw packet
+//!
+//! @param pHandle          - BLE Controller device handler.
+//! @param pui32Cmd         - Buffer to write the command from
+//! @param ui32Length       - Length of the command including the header
+//! @param pui32Response    - Buffer to store the response from the BLE controller
+//! @param pui32BytesReceived - Actually received number of bytes
+//!
+//! @return 32-bit status
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_command_write(void* pHandle, uint32_t* pui32Cmd, uint32_t ui32Length, uint32_t* pui32Response, uint32_t* pui32BytesReceived);
+
+//*****************************************************************************
+//
+//! @brief Check the state of the IRQ pin.
+//! @return Pin state
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_irq_read(void);
+
+//*****************************************************************************
+//
+//! @brief Check the state of the CLKREQ pin.
+//! @return Pin state
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_clkreq_read(void* pHandle);
+//*****************************************************************************
+//
+//! @brief Set the 32M crystal frequency based on the tested values at customer side.
+//!
+//! Set trim value smaller in case of negative frequency offset
+//!
+//! @param pHandle          - Pointer to device handle
+//! @param ui32TrimValue    - TrimValue : default is 0x1EC
+//!
+//! @note Refer to App Note Apollo4 Blue 32MHz Crystal Calibration
+//!
+//! @return  status from am_devices_cooper_status_t
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_crystal_trim_set(void *pHandle, uint32_t ui32TrimValue);
+
+//*****************************************************************************
+//
+//! @brief Reset the BLE controller and check if there's request to update
+//!
+//! @param pHandle
+//! @param pDevConfig
+//!
+//! @return status from am_devices_cooper_status_t
+//
+//*****************************************************************************
+extern uint32_t am_devices_cooper_reset_with_sbl_check(void* pHandle, am_devices_cooper_config_t* pDevConfig);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // AM_DEVICES_COOPER_H
+
+//*****************************************************************************
+//
+// End Doxygen group.
+//! @}
+//
+//*****************************************************************************
+

--- a/mcu/apollo4p/CMakeLists.txt
+++ b/mcu/apollo4p/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Ambiq HAL
 #
 # Copyright (c) 2023 Antmicro Ltd <www.antmicro.com>
+# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +12,7 @@ zephyr_library()
 zephyr_library_sources(hal/am_hal_global.c)
 zephyr_library_sources(hal/am_hal_pwrctrl.c)
 zephyr_library_sources(hal/am_hal_queue.c)
+zephyr_library_sources(hal/am_hal_security.c)
 zephyr_library_sources(hal/mcu/am_hal_bootrom_helper.c)
 zephyr_library_sources(hal/mcu/am_hal_cachectrl.c)
 zephyr_library_sources(hal/mcu/am_hal_interrupt.c)
@@ -45,3 +47,5 @@ if(CONFIG_AMBIQ_HAL_USE_MSPI)
     zephyr_library_sources(hal/mcu/am_hal_mspi.c)
     zephyr_library_sources(hal/mcu/am_hal_cmdq.c)
 endif()
+
+zephyr_include_directories(hal)


### PR DESCRIPTION
This PR imports the original Cooper (Apollo4x BLE controller) device files from AmbiqSuite SDK 4.4.0 and adapts them to support the new implemented HCI driver in Zephyr. Then we can support the general BLE samples for Apollo4 Blue Plus in Zephyr.