### PR TITLE
Stimer: remove disabling stmer's COMPARE interrupts in set delta api

### DIFF
--- a/mcu/apollo4p/hal/am_hal_stimer.c
+++ b/mcu/apollo4p/hal/am_hal_stimer.c
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2023, Ambiq Micro, Inc.
+// Copyright (c) 2024, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk_4_4_0-3c5977e664 of the AmbiqSuite Development Package.
+// This is part of revision stable-5d223aedc3 of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -254,18 +254,13 @@ am_hal_stimer_compare_delta_set(uint32_t ui32CmprInstance, uint32_t ui32Delta)
         return AM_HAL_STATUS_OUT_OF_RANGE;
     }
 #endif
-
-    // We cannot set COMPARE back to back
-    // Make sure we disable any previous COMPARE interrupts coming while we wait
-    // NOTE: This does not address stale interrupts once we have written the COMPARE...
-    // as it takes another 2 clocks for Writes to go through.
-    // So - a stale interrupt could still come, that needs to be ignored by application
-    uint32_t ui32CompareRestoreMsk = STIMER->STCFG & (STIMER_STCFG_COMPAREAEN_Msk << ui32CmprInstance);
-
     //
-    // Disable the Compare
+    //! @note Due to latency in write to COMPARE register to take effect, it is
+    //!  possible that the application could get a stale interrupt even after
+    //!  this API returns (a result of previous value of COMPARE).
+    //!
+    //! The application needs to handle these cases gracefully.
     //
-    STIMER->STCFG &= ~(STIMER_STCFG_COMPAREAEN_Msk << ui32CmprInstance);
 
     do
     {
@@ -298,10 +293,6 @@ am_hal_stimer_compare_delta_set(uint32_t ui32CmprInstance, uint32_t ui32Delta)
             // Set the delta
             //
             AM_REGVAL(AM_REG_STIMER_COMPARE(0, ui32CmprInstance)) = ui32Delta;
-            //
-            // Restore the Compare Enable
-            //
-            STIMER->STCFG |= ui32CompareRestoreMsk;
             //
             // Get a snapshot when we set COMPARE
             //


### PR DESCRIPTION
disabling stmer's COMPARE interrupts in am_hal_stimer_compare_delta_set() api has caused
tests/kernel/common/ failure, remove it due to it is duplicate to critical section protection in the following operation