### PR TITLE
hal: apollo3p: add more mspi controls

### DIFF
--- a/mcu/apollo3p/hal/am_hal_mspi.c
+++ b/mcu/apollo3p/hal/am_hal_mspi.c
@@ -2276,26 +2276,31 @@ uint32_t am_hal_mspi_control(void *pHandle,
             }
             break;
         }
+
+        case AM_HAL_MSPI_REQ_ISIZE_SET:
+        {
+            am_hal_mspi_instr_e *eInstr = (am_hal_mspi_instr_e *)pConfig;
+#ifndef AM_HAL_DISABLE_API_VALIDATION
+            if (!pConfig)
+            {
+                return AM_HAL_STATUS_INVALID_ARG;
+            }
+#endif // AM_HAL_DISABLE_API_VALIDATION
+
+            MSPIn(pMSPIState->ui32Module)->CFG_b.ISIZE = *eInstr;
+            break;
+        }
+
         case AM_HAL_MSPI_REQ_ASIZE_SET:
         {
-            uint8_t olen, nlen;
-
-            nlen = *((uint8_t *)pConfig);
-
-            //
-            //preventing the invalid case
-            //
-            if (nlen == 0)
+            am_hal_mspi_addr_e *eAddr = (am_hal_mspi_addr_e *)pConfig;
+#ifndef AM_HAL_DISABLE_API_VALIDATION
+            if (!pConfig)
             {
-                break;
+                return AM_HAL_STATUS_INVALID_ARG;
             }
-
-            olen = MSPIn(pMSPIState->ui32Module)->CFG_b.ASIZE + 1;
-            if (olen != nlen)
-            {
-                MSPIn(pMSPIState->ui32Module)->CFG_b.ASIZE = nlen - 1;
-            }
-            *((uint8_t *)pConfig) = olen;
+#endif // AM_HAL_DISABLE_API_VALIDATION
+            MSPIn(pMSPIState->ui32Module)->CFG_b.ASIZE = *eAddr;
             break;
         }
 
@@ -2317,6 +2322,26 @@ uint32_t am_hal_mspi_control(void *pHandle,
 
             break;
         }
+
+        case AM_HAL_MSPI_REQ_TIMING_SCAN:
+        {
+#ifndef AM_HAL_DISABLE_API_VALIDATION
+            if (!pConfig)
+            {
+                return AM_HAL_STATUS_INVALID_ARG;
+            }
+#endif // AM_HAL_DISABLE_API_VALIDATION
+            am_hal_mspi_timing_scan_t *pTiming = (am_hal_mspi_timing_scan_t *)pConfig;
+
+            MSPIn(ui32Module)->CFG_b.WRITELATENCY = pTiming->ui8WriteLatency;
+            MSPIn(ui32Module)->FLASH_b.XIPENWLAT  = (pTiming->ui8WriteLatency != 0);
+
+            MSPIn(ui32Module)->CFG_b.TURNAROUND   = pTiming->ui8Turnaround;
+            MSPIn(ui32Module)->FLASH_b.XIPENTURN  = (pTiming->ui8Turnaround != 0);
+
+            break;
+        }
+
         default:
             return AM_HAL_STATUS_INVALID_ARG;
     }

--- a/mcu/apollo3p/hal/am_hal_mspi.h
+++ b/mcu/apollo3p/hal/am_hal_mspi.h
@@ -262,6 +262,18 @@ extern "C"
     uint8_t                     ui8DQSDelay;
   } am_hal_mspi_dqs_t;
 
+  //
+  //! MSPI Timing Scan
+  //
+  typedef struct
+  {
+      bool            bTxNeg;
+      bool            bRxNeg;
+      bool            bRxCap;
+      uint8_t         ui8Turnaround;
+      uint8_t         ui8WriteLatency;
+  } am_hal_mspi_timing_scan_t;
+
   typedef struct
   {
     bool                        bLoop;
@@ -345,10 +357,14 @@ extern "C"
     //! Raw CQ transaction
     //! Pass am_hal_mspi_cq_raw_t * as pConfig
     AM_HAL_MSPI_REQ_CQ_RAW,
+    //! Alter the ISIZE of the CFG register
+    AM_HAL_MSPI_REQ_ISIZE_SET,
     //! Alter the ASIZE of the CFG register
     AM_HAL_MSPI_REQ_ASIZE_SET,
     // Set writlatncy when write date to nand flash
     AM_HAL_MSPI_REQ_NAND_FLASH_SET_WLAT,
+    //! Set the timing parameters
+    AM_HAL_MSPI_REQ_TIMING_SCAN,
 
     AM_HAL_MSPI_REQ_MAX
 


### PR DESCRIPTION
Added instruction and address length controls.
Added timing scan controls for future needs.