### PR TITLE
hal: spi: rename spi macros

### DIFF
--- a/mcu/apollo3/CMakeLists.txt
+++ b/mcu/apollo3/CMakeLists.txt
@@ -38,12 +38,12 @@ if(CONFIG_AMBIQ_HAL_USE_WDT)
     zephyr_library_sources(hal/am_hal_wdt.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIM)
+if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC)
     zephyr_library_sources(hal/am_hal_iom.c)
     zephyr_library_sources(hal/am_hal_cmdq.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_SPIS)
+if(CONFIG_AMBIQ_HAL_USE_SPID)
     zephyr_library_sources(hal/am_hal_ios.c)
 endif()
 

--- a/mcu/apollo3p/CMakeLists.txt
+++ b/mcu/apollo3p/CMakeLists.txt
@@ -38,12 +38,12 @@ if(CONFIG_AMBIQ_HAL_USE_WDT)
     zephyr_library_sources(hal/am_hal_wdt.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIM)
+if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC)
     zephyr_library_sources(hal/am_hal_iom.c)
     zephyr_library_sources(hal/am_hal_cmdq.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_SPIS)
+if(CONFIG_AMBIQ_HAL_USE_SPID)
     zephyr_library_sources(hal/am_hal_ios.c)
 endif()
 

--- a/mcu/apollo4p/CMakeLists.txt
+++ b/mcu/apollo4p/CMakeLists.txt
@@ -35,13 +35,13 @@ if(CONFIG_AMBIQ_HAL_USE_HWINFO)
     zephyr_library_sources(hal/mcu/am_hal_reset.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIM)
+if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC)
     zephyr_library_sources(hal/mcu/am_hal_iom.c)
     zephyr_library_sources(hal/mcu/am_hal_cmdq.c)
     zephyr_library_sources(hal/mcu/am_hal_fault.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_SPIS)
+if(CONFIG_AMBIQ_HAL_USE_SPID)
     zephyr_library_sources(hal/mcu/am_hal_ios.c)
 endif()
 


### PR DESCRIPTION
renamed spi macros according to zephyr coding standard