### PR TITLE
hal: apollo4p: usb: add UDC support 

### DIFF
--- a/mcu/apollo4p/CMakeLists.txt
+++ b/mcu/apollo4p/CMakeLists.txt
@@ -58,4 +58,8 @@ if(CONFIG_AMBIQ_HAL_USE_WDT)
     zephyr_library_sources(hal/am_hal_wdt.c)
 endif()
 
+if(CONFIG_AMBIQ_HAL_USE_USB)
+    zephyr_library_sources(hal/am_hal_usb.c)
+endif()
+
 zephyr_include_directories(hal)

--- a/mcu/apollo4p/CMakeLists.txt
+++ b/mcu/apollo4p/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 
 if(CONFIG_AMBIQ_HAL_USE_USB)
     zephyr_library_sources(hal/am_hal_usb.c)
+	add_compile_definitions(AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK)
 endif()
 
 zephyr_include_directories(hal)

--- a/mcu/apollo4p/hal/am_hal_usb.c
+++ b/mcu/apollo4p/hal/am_hal_usb.c
@@ -67,7 +67,7 @@
 //!       The USB controller will send STATUS ACK to USB Host regardless of the
 //!       selection.
 //
-#define AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
+// #define AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
 
 
 //*****************************************************************
@@ -238,10 +238,10 @@ typedef struct
     //! Endpoint transfer complete callback
     am_hal_usb_ep_xfer_complete_callback ep_xfer_complete_callback;
 
-    #ifndef AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
+#ifndef AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
     bool bPendingInEndData;
     bool bPendingOutEndData;
-    #endif
+#endif
 }
 am_hal_usb_state_t;
 
@@ -806,7 +806,6 @@ am_hal_usb_power_control(void *pHandle,
                          bool bRetainState)
 {
 
-
 #ifndef AM_HAL_DISABLE_API_VALIDATION
     //
     // Check to make sure this is a valid handle.
@@ -821,7 +820,6 @@ am_hal_usb_power_control(void *pHandle,
     uint32_t ui32Status;
     am_hal_usb_state_t *pState = (am_hal_usb_state_t *) pHandle;
     uint32_t ui32Module = pState->ui32Module;
-
 
 #ifndef AM_HAL_DISABLE_API_VALIDATION
     if ( ui32Module >= AM_REG_USB_NUM_MODULES )
@@ -1852,9 +1850,9 @@ am_hal_usb_ep0_xfer(am_hal_usb_state_t *pState, uint8_t ui8EpNum, uint8_t ui8EpD
 
     switch ( pState->eEP0State )
     {
-        #ifndef  AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
+#ifndef  AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
         case AM_HAL_USB_EP0_STATE_IDLE:
-            if((pState->bPendingInEndData || pState->bPendingOutEndData) && (ui16Len == 0))
+            if ((pState->bPendingInEndData || pState->bPendingOutEndData) && (ui16Len == 0))
             {
                 // Reset EP0 state and wait for the next command from host.
                 am_hal_usb_ep0_state_reset(pState);
@@ -1867,12 +1865,12 @@ am_hal_usb_ep0_xfer(am_hal_usb_state_t *pState, uint8_t ui8EpNum, uint8_t ui8EpD
                 return AM_HAL_STATUS_FAIL;
             }
             break;
-        #endif
+#endif
 
         case AM_HAL_USB_EP0_STATE_SETUP:
             if (ui16Len == 0x0)
             {
-                #ifndef  AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
+#ifndef  AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
                 // There are 2 conditions that we are entering to this handling:
                 // 1. Previous command was with data stage. However, the subsequent SETUP is
                 //    received in ISR before the ACK stage handling is done. For this case,
@@ -1881,7 +1879,7 @@ am_hal_usb_ep0_xfer(am_hal_usb_state_t *pState, uint8_t ui8EpNum, uint8_t ui8EpD
                 //    back to IDLE so that it is able to receive next SETUP correctly.
 
                 // Case 1:
-                if(pState->bPendingOutEndData || pState->bPendingInEndData)
+                if (pState->bPendingOutEndData || pState->bPendingInEndData)
                 {
                     am_hal_usb_xfer_reset(&pState->ep0_xfer);
                     pState->bPendingOutEndData = false;
@@ -1898,7 +1896,7 @@ am_hal_usb_ep0_xfer(am_hal_usb_state_t *pState, uint8_t ui8EpNum, uint8_t ui8EpD
                     pState->eEP0State =
                         (ui8EpDir == AM_HAL_USB_EP_DIR_IN) ? AM_HAL_USB_EP0_STATE_STATUS_TX : AM_HAL_USB_EP0_STATE_STATUS_RX;
                 }
-                #else
+#else
                 // Upper layer USB stack just use zero length packet to confirm no data stage
                 // some requests like CLEAR_FEARURE, SET_ADDRESS, SET_CONFIGRATION, etc.
                 // end the control transfer from device side
@@ -1908,7 +1906,7 @@ am_hal_usb_ep0_xfer(am_hal_usb_state_t *pState, uint8_t ui8EpNum, uint8_t ui8EpD
                 // Will indicate request is completed
                 pState->eEP0State =
                     (ui8EpDir == AM_HAL_USB_EP_DIR_IN) ? AM_HAL_USB_EP0_STATE_STATUS_TX : AM_HAL_USB_EP0_STATE_STATUS_RX;
-                #endif
+#endif
             }
             else
             {
@@ -1928,11 +1926,11 @@ am_hal_usb_ep0_xfer(am_hal_usb_state_t *pState, uint8_t ui8EpNum, uint8_t ui8EpD
                     // Read requests handling
                     case AM_HAL_USB_EP_DIR_IN:
 
-                        #ifndef  AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
+#ifndef  AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
                         // Flag that we need to handle End Data later for OUT
                         // direction
                         pState->bPendingOutEndData = true;
-                        #endif
+#endif
 
                         // Load the first packet
                         if (ui16Len < maxpacket)
@@ -1958,11 +1956,11 @@ am_hal_usb_ep0_xfer(am_hal_usb_state_t *pState, uint8_t ui8EpNum, uint8_t ui8EpD
                         // Write requests handling
                         // Waiting the host sending the data to the device
 
-                        #ifndef  AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
+#ifndef  AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK
                         // Flag that we need to handle End Data later for IN
                         // direction
                         pState->bPendingInEndData = true;
-                        #endif
+#endif
 
                         pState->ep0_xfer.remaining = ui16Len;
                         pState->eEP0State = AM_HAL_USB_EP0_STATE_DATA_RX;
@@ -3099,8 +3097,8 @@ am_hal_usb_control(am_hal_usb_control_e eControl, void *pArgs)
                 ui32RetVal = AM_HAL_STATUS_INVALID_ARG;
                 break;
             }
-            ui32RetVal =  am_hal_usb_setHFRC2( *((am_hal_usb_hs_clock_type *) pArgs)) ;
-            break ;
+            ui32RetVal =  am_hal_usb_setHFRC2( *((am_hal_usb_hs_clock_type *) pArgs));
+            break;
 
         default:
             ui32RetVal = AM_HAL_STATUS_INVALID_ARG;

--- a/mcu/apollo4p/hal/am_hal_usb.c
+++ b/mcu/apollo4p/hal/am_hal_usb.c
@@ -2931,6 +2931,7 @@ am_hal_usb_interrupt_service(void *pHandle,
         USBPHY->REG10 |= 0x2;
 
         // Back to active state
+        INTRUSBE_Suspend_Enable(pUSB);
         pState->eDevState = AM_HAL_USB_DEV_STATE_RESUMING;
         if (pState->dev_evt_callback)
         {
@@ -2983,8 +2984,9 @@ am_hal_usb_interrupt_service(void *pHandle,
 #endif
 
         //
-        // Always enable the SuspendM
+        // Enable interrupt for USB suspend. Discard suspend interrupt event.
         //
+        ui32IntrUsbStatus &= ~USB_INTRUSB_Suspend_Msk;
         INTRUSBE_Suspend_Enable(pUSB);
 
         if (pState->dev_evt_callback)
@@ -3054,6 +3056,7 @@ am_hal_usb_interrupt_service(void *pHandle,
         //
         USBPHY->REG10 &= 0xFD;
 
+        INTRUSBE_Suspend_Disable(pUSB);
         pState->eDevState = AM_HAL_USB_DEV_STATE_SUSPENDING;
         if (pState->dev_evt_callback)
         {

--- a/mcu/apollo4p/hal/am_hal_usb.h
+++ b/mcu/apollo4p/hal/am_hal_usb.h
@@ -157,7 +157,6 @@ typedef enum
 }
 am_hal_usb_xfer_code_e;
 
-
 //*****************************************************************************
 //
 //! @brief Enum for the USB control call
@@ -179,7 +178,6 @@ typedef enum
     //! this is controller by an argument of type am_hal_usb_hs_clock_type
     //! this is how modules configure the HFRC2
     AM_HAL_CLKGEN_CONTROL_SET_HFRC2_TYPE,
-
 
 } am_hal_usb_control_e;
 
@@ -861,7 +859,6 @@ extern uint32_t am_hal_usb_control(am_hal_usb_control_e eControl, void *pArgs);
 //
 //*****************************************************************************
 extern uint32_t am_hal_usb_setHFRC2(am_hal_usb_hs_clock_type tUsbHsClockType);
-
 
 //*****************************************************************************
 //

--- a/mcu/apollo4p/hal/am_hal_usb.h
+++ b/mcu/apollo4p/hal/am_hal_usb.h
@@ -863,6 +863,18 @@ extern uint32_t am_hal_usb_control(am_hal_usb_control_e eControl, void *pArgs);
 extern uint32_t am_hal_usb_setHFRC2(am_hal_usb_hs_clock_type tUsbHsClockType);
 
 
+//*****************************************************************************
+//
+//! @brief Reset EP State
+//!
+//! @param pHandle   - handle for the module instance.
+//! @param ui8EpAddr - USB endpoint address for state reset
+//!
+//! @return one of am_hal_status_e like AM_HAL_STATUS_SUCCESS
+//
+//*****************************************************************************
+extern uint32_t am_hal_usb_ep_state_reset(void *pHandle, uint8_t ui8EpAddr);
+
 #ifdef __cplusplus
 }
 #endif
@@ -875,4 +887,3 @@ extern uint32_t am_hal_usb_setHFRC2(am_hal_usb_hs_clock_type tUsbHsClockType);
 //! @}
 //
 //*****************************************************************************
-


### PR DESCRIPTION
Added changes needed to support UDC driver including: 
1. `CONFIG_AMBIQ_HAL_USE_USB` flag to decide whether to include USB HAL for compilation
1. `AM_HAL_USB_CTRL_XFR_WAIT_STATUS_ACK_ZLP_FROM_STACK` flag to control EP0 control transfer behavior
1. `am_hal_usb_ep_state_reset` API to reset EP state by UDC driver
1.  Handle condition where OUT packet receive completed before UDC assign endpoint buffer to the endpoint.
1.  Refined suspend/resume event handling, to avoid false suspend event during bus reset. 