### PR TITLE
hal: iom: add back old spi macro

### DIFF
--- a/mcu/apollo3/CMakeLists.txt
+++ b/mcu/apollo3/CMakeLists.txt
@@ -38,7 +38,7 @@ if(CONFIG_AMBIQ_HAL_USE_WDT)
     zephyr_library_sources(hal/am_hal_wdt.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC)
+if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC OR CONFIG_AMBIQ_HAL_USE_SPI)
     zephyr_library_sources(hal/am_hal_iom.c)
     zephyr_library_sources(hal/am_hal_cmdq.c)
 endif()

--- a/mcu/apollo3p/CMakeLists.txt
+++ b/mcu/apollo3p/CMakeLists.txt
@@ -38,7 +38,7 @@ if(CONFIG_AMBIQ_HAL_USE_WDT)
     zephyr_library_sources(hal/am_hal_wdt.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC)
+if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC OR CONFIG_AMBIQ_HAL_USE_SPI)
     zephyr_library_sources(hal/am_hal_iom.c)
     zephyr_library_sources(hal/am_hal_cmdq.c)
 endif()

--- a/mcu/apollo4p/CMakeLists.txt
+++ b/mcu/apollo4p/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CONFIG_AMBIQ_HAL_USE_HWINFO)
     zephyr_library_sources(hal/mcu/am_hal_reset.c)
 endif()
 
-if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC)
+if(CONFIG_AMBIQ_HAL_USE_I2C OR CONFIG_AMBIQ_HAL_USE_SPIC OR CONFIG_AMBIQ_HAL_USE_SPI)
     zephyr_library_sources(hal/mcu/am_hal_iom.c)
     zephyr_library_sources(hal/mcu/am_hal_cmdq.c)
     zephyr_library_sources(hal/mcu/am_hal_fault.c)


### PR DESCRIPTION
added back CONFIG_AMBIQ_HAL_USE_SPI to get backward compatibility