### PR TITLE
fix cmake warning when BLE is not needed

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,15 +1,10 @@
 # Ambiq HAL Components
 #
-# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
+# Copyright (c) 2025 Ambiq Micro Inc. <www.ambiq.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
-if(CONFIG_SOC_APOLLO4P_BLUE)
-    zephyr_library_sources(bluetooth/am_devices_cooper.c)
-elseif(CONFIG_SOC_APOLLO3P_BLUE OR CONFIG_SOC_APOLLO3_BLUE)
-    zephyr_library_sources(bluetooth/am_apollo3_bt_support.c)
+if(CONFIG_AMBIQ_COMPONENT_USE_BT)
+    add_subdirectory(bluetooth)
+    zephyr_include_directories(bluetooth)
 endif()
-
-zephyr_include_directories(bluetooth)

--- a/components/bluetooth/CMakeLists.txt
+++ b/components/bluetooth/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Ambiq HAL Components
+#
+# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+if(CONFIG_SOC_APOLLO4P_BLUE)
+    zephyr_library_sources(am_devices_cooper.c)
+elseif(CONFIG_SOC_APOLLO3P_BLUE OR CONFIG_SOC_APOLLO3_BLUE)
+    zephyr_library_sources(am_apollo3_bt_support.c)
+endif()


### PR DESCRIPTION
Empty zephyr_library() in hal_ambiq\components is producing warning when BLE is not needed for compile.