### PR TITLE
hal: usb: added unified handling for USB ISR handling

### DIFF
--- a/mcu/apollo4p/hal/am_hal_usb.h
+++ b/mcu/apollo4p/hal/am_hal_usb.h
@@ -833,7 +833,26 @@ extern void am_hal_usb_interrupt_service(void *pHandle,
                                          uint32_t ui32IntrInStatus,
                                          uint32_t ui32IntrOutStatus);
 
-
+//****************************************************************************
+//
+//! @brief Macro to read and handle USB interrupts
+//!
+//! Application / USB stack can either call this macro, or implement its custom
+//! handling when usb isr is received
+//
+//****************************************************************************
+#define am_hal_usb_handle_isr(pHandle)                  \
+    {                                                   \
+        uint32_t int_status[3];                         \
+        am_hal_usb_intr_status_get(pHandle,             \
+                                    &int_status[0],     \
+                                    &int_status[1],     \
+                                    &int_status[2]);    \
+        am_hal_usb_interrupt_service(pHandle,           \
+                                     int_status[0],     \
+                                     int_status[1],     \
+                                     int_status[2]);    \
+    }
 
 //*****************************************************************************
 //

--- a/mcu/apollo510/hal/am_hal_usb.h
+++ b/mcu/apollo510/hal/am_hal_usb.h
@@ -1039,6 +1039,31 @@ extern uint32_t am_hal_usb_intr_status_get(void *pHandle, uint32_t *ui32IntrUsbS
 extern void am_hal_usb_interrupt_service(void *pHandle, uint32_t ui32IntrUsbStatus, uint32_t ui32IntrInStatus, uint32_t ui32IntrOutStatus,
                                         uint32_t ui32IntrDMAStatus, uint32_t ui32IntrAutoDMAStatus);
 
+//****************************************************************************
+//
+//! @brief Macro to read and handle USB interrupts
+//!
+//! Application / USB stack can either call this macro, or implement its custom
+//! handling when usb isr is received
+//
+//****************************************************************************
+#define am_hal_usb_handle_isr(pHandle)                  \
+    {                                                   \
+        uint32_t int_status[5];                         \
+        am_hal_usb_intr_status_get(pHandle,             \
+                                    &int_status[0],     \
+                                    &int_status[1],     \
+                                    &int_status[2],     \
+                                    &int_status[3],     \
+                                    &int_status[4]);    \
+        am_hal_usb_interrupt_service(pHandle,           \
+                                     int_status[0],     \
+                                     int_status[1],     \
+                                     int_status[2],     \
+                                     int_status[3],     \
+                                     int_status[4]);    \
+    }
+
 //*****************************************************************************
 //
 //! @brief Set USB Xfer Mode
@@ -1088,4 +1113,3 @@ extern void am_hal_usb_ep_state_reset(void *pHandle, uint8_t ui8EpAddr);
 //! @}
 //
 //*****************************************************************************
-


### PR DESCRIPTION
Introduced a macro that utilizes existing API to provide unified interface for interrupt service routine handling.